### PR TITLE
Fix Python 3.14 build failure

### DIFF
--- a/omeco-python/Cargo.toml
+++ b/omeco-python/Cargo.toml
@@ -13,5 +13,5 @@ crate-type = ["cdylib"]
 
 [dependencies]
 omeco = { path = "../omeco" }
-pyo3 = { version = "0.23", features = ["extension-module"] }
+pyo3 = { version = "0.27", features = ["extension-module"] }
 

--- a/omeco-python/pyproject.toml
+++ b/omeco-python/pyproject.toml
@@ -19,6 +19,8 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Programming Language :: Rust",
     "Topic :: Scientific/Engineering",
 ]

--- a/omeco-python/src/lib.rs
+++ b/omeco-python/src/lib.rs
@@ -48,7 +48,7 @@ impl PyNestedEinsum {
     /// Returns a dict with structure:
     /// - For leaf: {"tensor_index": int}
     /// - For node: {"args": [child_dicts], "eins": {"ixs": [[int]], "iy": [int]}}
-    fn to_dict(&self, py: Python<'_>) -> PyResult<PyObject> {
+    fn to_dict(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
         nested_to_dict(py, &self.inner)
     }
 
@@ -61,7 +61,7 @@ impl PyNestedEinsum {
     }
 }
 
-fn nested_to_dict(py: Python<'_>, nested: &NestedEinsum<i64>) -> PyResult<PyObject> {
+fn nested_to_dict(py: Python<'_>, nested: &NestedEinsum<i64>) -> PyResult<Py<PyAny>> {
     use pyo3::types::PyDict;
 
     let dict = PyDict::new(py);
@@ -70,7 +70,7 @@ fn nested_to_dict(py: Python<'_>, nested: &NestedEinsum<i64>) -> PyResult<PyObje
             dict.set_item("tensor_index", *tensor_index)?;
         }
         NestedEinsum::Node { args, eins } => {
-            let args_list: Vec<PyObject> = args
+            let args_list: Vec<Py<PyAny>> = args
                 .iter()
                 .map(|arg| nested_to_dict(py, arg))
                 .collect::<PyResult<_>>()?;


### PR DESCRIPTION
## Summary

- Upgrade PyO3 from 0.23 to 0.27 (supports Python 3.14)
- Add Python 3.13 and 3.14 classifiers to pyproject.toml
- Fix deprecation warnings: `PyObject` → `Py<PyAny>`

## Test plan

- [x] Build compiles without warnings
- [x] All 39 tests pass with Python 3.14

Fixes #3