### PR TITLE
Add exhaustive search optimizer

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ When contracting multiple tensors together, the order of contractions significan
 This library provides:
 
 - **GreedyMethod**: Fast O(n² log n) greedy algorithm for contraction order
+- **ExhaustiveSearch**: Exact dynamic programming for small contraction networks
 - **TreeSA**: Simulated annealing for higher quality contraction orders
 - **TreeSASlicer**: Automatic slicing optimization to reduce memory usage
 
@@ -51,7 +52,7 @@ omeco = "0.1"
 ```python
 from omeco import (
     optimize_code, slice_code, contraction_complexity, sliced_complexity,
-    GreedyMethod, TreeSA, TreeSASlicer, ScoreFunction
+    GreedyMethod, ExhaustiveSearch, TreeSA, TreeSASlicer, ScoreFunction
 )
 
 # Matrix chain: A[0,1] × B[1,2] × C[2,3] → D[0,3]
@@ -82,7 +83,7 @@ orders and slicing for lower peak memory.
 
 ```rust
 use omeco::{
-    EinCode, GreedyMethod, TreeSASlicer, slice_code,
+    EinCode, GreedyMethod, ExhaustiveSearch, TreeSASlicer, slice_code,
     contraction_complexity, optimize_code, sliced_complexity,
 };
 use std::collections::HashMap;
@@ -146,6 +147,26 @@ let result = optimize_code(&code, &sizes, &stochastic);
 **Parameters:**
 - `alpha`: Balances output size vs input size reduction (0.0 to 1.0)
 - `temperature`: Enables Boltzmann sampling (0.0 = deterministic)
+
+### ExhaustiveSearch
+
+Exact dynamic programming for small networks:
+
+```rust
+use omeco::{EinCode, ExhaustiveSearch, optimize_code};
+
+let code = EinCode::new(
+    vec![vec!['a', 'b'], vec!['b', 'c'], vec!['c', 'd']],
+    vec!['a', 'd']
+);
+let sizes = omeco::uniform_size_dict(&code, 10);
+
+let result = optimize_code(&code, &sizes, &ExhaustiveSearch::default());
+```
+
+`ExhaustiveSearch` minimizes total FLOP count within each connected component.
+It supports hyperedges and shared output indices, but nontrivial inputs with
+partial traces or dangling summed indices are outside its exact-search scope.
 
 ### TreeSA
 

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -13,6 +13,7 @@
   - [Complexity Metrics](./concepts/complexity-metrics.md)
 - [Algorithms](./algorithms/README.md)
   - [Greedy Method](./algorithms/greedy-method.md)
+  - [Exhaustive Search](./algorithms/exhaustive-search.md)
   - [TreeSA](./algorithms/tree-sa.md)
   - [Algorithm Comparison](./algorithms/comparison.md)
 

--- a/docs/src/algorithms/README.md
+++ b/docs/src/algorithms/README.md
@@ -1,12 +1,13 @@
 # Algorithms
 
-omeco provides two main optimization algorithms with different speed-quality trade-offs.
+omeco provides three optimization algorithms with different speed-quality trade-offs.
 
 ## Algorithm Comparison
 
 | Algorithm | Speed | Quality | Use Case |
 |-----------|-------|---------|----------|
 | **GreedyMethod** | Fast (seconds) | Good | Quick optimization, large networks |
+| **ExhaustiveSearch** | Exponential | Optimal | Small networks, exact baselines |
 | **TreeSA** | Slower (minutes) | Better | High-quality solutions, important workloads |
 
 ## Quick Guide
@@ -22,9 +23,15 @@ omeco provides two main optimization algorithms with different speed-quality tra
 - Greedy result is too slow/large
 - Working with complex tensor networks
 
+**Use ExhaustiveSearch when:**
+- The network is small enough for exact dynamic programming
+- You need a known-optimal FLOP-count baseline
+- You are testing or benchmarking heuristic optimizers
+
 ## Topics
 
 - [Greedy Method](./greedy-method.md) - Fast O(n² log n) optimization
+- [Exhaustive Search](./exhaustive-search.md) - Exact dynamic programming for small networks
 - [TreeSA](./tree-sa.md) - Simulated annealing for quality
 - [Algorithm Comparison](./comparison.md) - Detailed benchmarks
 

--- a/docs/src/algorithms/comparison.md
+++ b/docs/src/algorithms/comparison.md
@@ -1,16 +1,16 @@
 # Algorithm Comparison
 
-Detailed comparison of GreedyMethod vs TreeSA.
+Detailed comparison of GreedyMethod, ExhaustiveSearch, and TreeSA.
 
 ## Quick Summary
 
-| Metric | GreedyMethod | TreeSA |
-|--------|--------------|--------|
-| **Speed** | Seconds | Minutes |
-| **Solution Quality** | Good | Better |
-| **Deterministic** | Yes (default) | No |
-| **Scalability** | 100+ tensors | 50-100 tensors |
-| **Tuning Required** | Minimal | Some |
+| Metric | GreedyMethod | ExhaustiveSearch | TreeSA |
+|--------|--------------|------------------|--------|
+| **Speed** | Seconds | Exponential | Minutes |
+| **Solution Quality** | Good | Optimal FLOP count | Better |
+| **Deterministic** | Yes (default) | Yes | No |
+| **Scalability** | 100+ tensors | Small networks | 50-100 tensors |
+| **Tuning Required** | Minimal | None | Some |
 
 ## Performance Benchmarks
 
@@ -143,6 +143,8 @@ memory_reduction = 2 ** (comp_greedy.sc - comp_sa.sc)  # 2.5x less memory
 ```
 Start
   │
+  ├─ Need a small exact baseline? ──→ ExhaustiveSearch
+  │
   ├─ Need results in <1 second? ──→ GreedyMethod
   │
   ├─ Problem is a chain/tree? ──→ GreedyMethod
@@ -181,6 +183,7 @@ if comp_greedy.tc > 35.0:  # Too slow
 
 | Scenario | Algorithm | Configuration |
 |----------|-----------|---------------|
+| Exact small-network baseline | ExhaustiveSearch | Default |
 | Quick prototyping | GreedyMethod | Default |
 | Production (simple) | GreedyMethod | Default |
 | Production (complex) | TreeSA | `TreeSA.fast()` |
@@ -190,5 +193,6 @@ if comp_greedy.tc > 35.0:  # Too slow
 ## Next Steps
 
 - [Greedy Method](./greedy-method.md) - Details on greedy algorithm
+- [Exhaustive Search](./exhaustive-search.md) - Exact optimizer for small networks
 - [TreeSA](./tree-sa.md) - Details on simulated annealing
 - [Score Function](../guides/score-function.md) - Tune for your hardware

--- a/docs/src/algorithms/exhaustive-search.md
+++ b/docs/src/algorithms/exhaustive-search.md
@@ -1,0 +1,50 @@
+# Exhaustive Search
+
+`ExhaustiveSearch` is an exact contraction-order optimizer for small tensor
+networks. It uses dynamic programming over tensor subsets and minimizes total
+contraction FLOP count within each connected component.
+
+## Usage
+
+Python:
+
+```python
+from omeco import ExhaustiveSearch, optimize_code
+
+ixs = [[0, 1], [1, 2], [2, 3]]
+out = [0, 3]
+sizes = {0: 2, 1: 3, 2: 4, 3: 5}
+
+tree = optimize_code(ixs, out, sizes, ExhaustiveSearch())
+```
+
+Rust:
+
+```rust
+use omeco::{EinCode, ExhaustiveSearch, optimize_code};
+
+let code = EinCode::new(
+    vec![vec!['i', 'j'], vec!['j', 'k'], vec!['k', 'l']],
+    vec!['i', 'l'],
+);
+let sizes = omeco::uniform_size_dict(&code, 10);
+
+let tree = optimize_code(&code, &sizes, &ExhaustiveSearch::default()).unwrap();
+```
+
+## Scope
+
+The exact search supports hyperedges and shared output indices, including batch
+or diagonal-style indices that appear in multiple tensors and remain in the
+output. Disconnected networks are optimized component by component and combined
+with outer products.
+
+For nontrivial networks, `ExhaustiveSearch` rejects partial traces and dangling
+summed indices because those require unary tensor operations outside the binary
+contraction tree search. One- and two-tensor inputs are returned directly.
+
+## When To Use
+
+Use `ExhaustiveSearch` for small networks, regression tests, and exact baselines
+when comparing heuristic optimizers. For larger networks, use `GreedyMethod` for
+speed or `TreeSA` for a higher-quality heuristic search.

--- a/docs/src/api-reference.md
+++ b/docs/src/api-reference.md
@@ -25,7 +25,7 @@ Optimize tensor contraction order.
 - `ixs`: List of index lists for each tensor (e.g., `[[0, 1], [1, 2]]`)
 - `out`: Output indices (e.g., `[0, 2]`)
 - `sizes`: Dictionary mapping indices to dimensions (e.g., `{0: 10, 1: 20, 2: 10}`)
-- `optimizer`: Optimizer instance (default: `GreedyMethod()`)
+- `optimizer`: Optimizer instance (`GreedyMethod`, `ExhaustiveSearch`, or `TreeSA`; default: `GreedyMethod()`)
 
 **Returns**: `NestedEinsum` representing the optimized contraction tree
 
@@ -156,6 +156,26 @@ GreedyMethod()
 
 # Stochastic variant
 GreedyMethod(temperature=1.0, max_branches=5)
+```
+
+#### `ExhaustiveSearch`
+
+```python
+class ExhaustiveSearch:
+    def __init__(self, verbose: bool = False)
+```
+
+Exact dynamic-programming optimizer for small tensor networks. It minimizes
+total FLOP count within each connected component.
+
+**Parameters**:
+- `verbose`: Print progress information during the search
+
+**Example**:
+```python
+from omeco import ExhaustiveSearch, optimize_code
+
+tree = optimize_code(ixs, out, sizes, ExhaustiveSearch())
 ```
 
 #### `TreeSA`

--- a/omeco-python/README.md
+++ b/omeco-python/README.md
@@ -12,9 +12,10 @@ Ported from [OMEinsumContractionOrders.jl](https://github.com/TensorBFS/OMEinsum
 
 When contracting multiple tensors together, the order of contractions significantly affects computational cost. Finding the optimal contraction order is NP-complete, but good heuristics can find near-optimal solutions quickly.
 
-This library provides two optimization algorithms:
+This library provides three optimization algorithms:
 
 - **GreedyMethod**: Fast O(n² log n) greedy algorithm
+- **ExhaustiveSearch**: Exact dynamic programming for small networks
 - **TreeSA**: Simulated annealing for higher quality solutions
 
 ## Installation
@@ -155,7 +156,7 @@ orders and slicing for lower peak memory.
 
 ```rust
 use omeco::{
-    EinCode, GreedyMethod, SlicedEinsum, contraction_complexity, optimize_code, sliced_complexity,
+    EinCode, GreedyMethod, ExhaustiveSearch, SlicedEinsum, contraction_complexity, optimize_code, sliced_complexity,
 };
 use std::collections::HashMap;
 
@@ -215,6 +216,26 @@ let result = optimize_code(&code, &sizes, &stochastic);
 **Parameters:**
 - `alpha`: Balances output size vs input size reduction (0.0 to 1.0)
 - `temperature`: Enables Boltzmann sampling (0.0 = deterministic)
+
+### ExhaustiveSearch
+
+Exact dynamic programming for small networks:
+
+```rust
+use omeco::{EinCode, ExhaustiveSearch, optimize_code};
+
+let code = EinCode::new(
+    vec![vec!['a', 'b'], vec!['b', 'c'], vec!['c', 'd']],
+    vec!['a', 'd']
+);
+let sizes = omeco::uniform_size_dict(&code, 10);
+
+let result = optimize_code(&code, &sizes, &ExhaustiveSearch::default());
+```
+
+`ExhaustiveSearch` minimizes total FLOP count within each connected component.
+It is intended for small networks and reports unsupported nontrivial inputs
+that require unary traces or dangling summed-index contractions.
 
 ### TreeSA
 

--- a/omeco-python/python/omeco/__init__.py
+++ b/omeco-python/python/omeco/__init__.py
@@ -11,6 +11,9 @@ Classes:
     GreedyMethod: Fast greedy optimizer.
         GreedyMethod(alpha=0.0, temperature=0.0)
 
+    ExhaustiveSearch: Exact optimizer for small tensor networks.
+        ExhaustiveSearch(verbose=False)
+
     TreeSA: Simulated annealing optimizer.
         TreeSA(ntrials=10, niters=50, betas=None, score=None)
         TreeSA.fast(score=None)
@@ -60,10 +63,12 @@ from omeco._core import (
     ContractionComplexity,
     ScoreFunction,
     GreedyMethod,
+    ExhaustiveSearch,
     TreeSA,
     TreeSASlicer,
     # Functions
     optimize_code,
+    optimize_exhaustive,
     contraction_complexity,
     sliced_complexity,
     slice_code,
@@ -77,12 +82,13 @@ __all__ = [
     "ContractionComplexity",
     "ScoreFunction",
     "GreedyMethod",
+    "ExhaustiveSearch",
     "TreeSA",
     "TreeSASlicer",
     "optimize_code",
+    "optimize_exhaustive",
     "contraction_complexity",
     "sliced_complexity",
     "slice_code",
     "uniform_size_dict",
 ]
-

--- a/omeco-python/src/lib.rs
+++ b/omeco-python/src/lib.rs
@@ -5,8 +5,8 @@ use pyo3::prelude::*;
 use std::collections::HashMap;
 
 use omeco::{
-    CodeOptimizer, ContractionComplexity, EinCode, GreedyMethod, NestedEinsum, ScoreFunction,
-    SlicedEinsum, TreeSA, TreeSASlicer,
+    CodeOptimizer, ContractionComplexity, EinCode, ExhaustiveSearch, GreedyMethod, NestedEinsum,
+    ScoreFunction, SlicedEinsum, TreeSA, TreeSASlicer,
 };
 
 /// A contraction order represented as a nested einsum tree.
@@ -417,6 +417,42 @@ impl PyGreedyMethod {
     }
 }
 
+/// Exact optimizer for small contraction networks.
+///
+/// Args:
+///     verbose: Print progress information during the exhaustive search.
+///              Default: False.
+#[pyclass(name = "ExhaustiveSearch")]
+#[derive(Clone)]
+pub struct PyExhaustiveSearch {
+    inner: ExhaustiveSearch,
+}
+
+#[pymethods]
+impl PyExhaustiveSearch {
+    /// Create a new exact optimizer.
+    #[new]
+    #[pyo3(signature = (verbose=false))]
+    fn new(verbose: bool) -> Self {
+        Self {
+            inner: ExhaustiveSearch::new(verbose),
+        }
+    }
+
+    /// Get the verbose flag.
+    #[getter]
+    fn verbose(&self) -> bool {
+        self.inner.verbose
+    }
+
+    fn __repr__(&self) -> String {
+        format!(
+            "ExhaustiveSearch(verbose={})",
+            if self.inner.verbose { "True" } else { "False" }
+        )
+    }
+}
+
 /// Simulated annealing optimizer for contraction order.
 ///
 /// Args:
@@ -700,6 +736,32 @@ fn optimize_treesa(
         .ok_or_else(|| PyValueError::new_err("Optimization failed"))
 }
 
+/// Optimize the contraction order using exact exhaustive search.
+///
+/// Args:
+///     ixs: List of index lists for each tensor.
+///     out: Output indices.
+///     sizes: Dictionary mapping indices to their dimensions.
+///     optimizer: ExhaustiveSearch optimizer configuration.
+///
+/// Returns:
+///     Optimized contraction tree as NestedEinsum.
+#[pyfunction]
+#[pyo3(signature = (ixs, out, sizes, optimizer=None))]
+fn optimize_exhaustive(
+    ixs: Vec<Vec<i64>>,
+    out: Vec<i64>,
+    sizes: HashMap<i64, usize>,
+    optimizer: Option<PyExhaustiveSearch>,
+) -> PyResult<PyNestedEinsum> {
+    let code = EinCode::new(ixs, out);
+    let opt = optimizer.unwrap_or_else(|| PyExhaustiveSearch::new(false));
+
+    omeco::optimize_exhaustive(&code, &sizes, &opt.inner)
+        .map(|inner| PyNestedEinsum { inner })
+        .map_err(|err| PyValueError::new_err(err.to_string()))
+}
+
 /// Compute the contraction complexity of an optimized tree.
 ///
 /// .. deprecated:: 0.3.0
@@ -847,10 +909,11 @@ fn slice_code(
         .ok_or_else(|| PyValueError::new_err("Slicing failed"))
 }
 
-/// Unified optimizer type that can be either GreedyMethod or TreeSA.
+/// Unified optimizer type for contraction order optimization.
 #[derive(FromPyObject)]
 enum PyOptimizer {
     Greedy(PyGreedyMethod),
+    Exhaustive(PyExhaustiveSearch),
     TreeSA(PyTreeSA),
 }
 
@@ -862,17 +925,19 @@ enum PyOptimizer {
 ///     ixs: List of index lists for each tensor (e.g., [[0, 1], [1, 2]]).
 ///     out: Output indices (e.g., [0, 2]).
 ///     sizes: Dictionary mapping indices to their dimensions.
-///     optimizer: Optimizer to use (GreedyMethod or TreeSA). Defaults to GreedyMethod().
+///     optimizer: Optimizer to use (GreedyMethod, ExhaustiveSearch, or TreeSA).
+///                Defaults to GreedyMethod().
 ///
 /// Returns:
 ///     Optimized contraction tree as NestedEinsum.
 ///
 /// Example:
-///     >>> from omeco import optimize_code, GreedyMethod, TreeSA
+///     >>> from omeco import optimize_code, GreedyMethod, ExhaustiveSearch, TreeSA
 ///     >>> ixs = [[0, 1], [1, 2], [2, 3]]
 ///     >>> out = [0, 3]
 ///     >>> sizes = {0: 100, 1: 50, 2: 80, 3: 100}
 ///     >>> tree = optimize_code(ixs, out, sizes, GreedyMethod())
+///     >>> tree = optimize_code(ixs, out, sizes, ExhaustiveSearch())
 ///     >>> tree = optimize_code(ixs, out, sizes, TreeSA.fast())
 #[pyfunction]
 #[pyo3(signature = (ixs, out, sizes, optimizer=None))]
@@ -885,14 +950,22 @@ fn optimize_code(
     let code = EinCode::new(ixs, out);
 
     let result = match optimizer {
-        Some(PyOptimizer::Greedy(opt)) => opt.inner.optimize(&code, &sizes),
-        Some(PyOptimizer::TreeSA(opt)) => opt.inner.optimize(&code, &sizes),
-        None => GreedyMethod::default().optimize(&code, &sizes),
+        Some(PyOptimizer::Greedy(opt)) => opt
+            .inner
+            .optimize(&code, &sizes)
+            .ok_or_else(|| PyValueError::new_err("Optimization failed")),
+        Some(PyOptimizer::Exhaustive(opt)) => omeco::optimize_exhaustive(&code, &sizes, &opt.inner)
+            .map_err(|err| PyValueError::new_err(err.to_string())),
+        Some(PyOptimizer::TreeSA(opt)) => opt
+            .inner
+            .optimize(&code, &sizes)
+            .ok_or_else(|| PyValueError::new_err("Optimization failed")),
+        None => GreedyMethod::default()
+            .optimize(&code, &sizes)
+            .ok_or_else(|| PyValueError::new_err("Optimization failed")),
     };
 
-    result
-        .map(|inner| PyNestedEinsum { inner })
-        .ok_or_else(|| PyValueError::new_err("Optimization failed"))
+    result.map(|inner| PyNestedEinsum { inner })
 }
 
 /// Python module for omeco tensor network contraction order optimization.
@@ -903,10 +976,12 @@ fn _core(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PyContractionComplexity>()?;
     m.add_class::<PyScoreFunction>()?;
     m.add_class::<PyGreedyMethod>()?;
+    m.add_class::<PyExhaustiveSearch>()?;
     m.add_class::<PyTreeSA>()?;
     m.add_class::<PyTreeSASlicer>()?;
     m.add_function(wrap_pyfunction!(optimize_code, m)?)?;
     m.add_function(wrap_pyfunction!(optimize_greedy, m)?)?;
+    m.add_function(wrap_pyfunction!(optimize_exhaustive, m)?)?;
     m.add_function(wrap_pyfunction!(optimize_treesa, m)?)?;
     m.add_function(wrap_pyfunction!(contraction_complexity, m)?)?;
     m.add_function(wrap_pyfunction!(sliced_complexity, m)?)?;

--- a/omeco-python/tests/test_omeco.py
+++ b/omeco-python/tests/test_omeco.py
@@ -3,10 +3,12 @@
 import pytest
 from omeco import (
     GreedyMethod,
+    ExhaustiveSearch,
     TreeSA,
     TreeSASlicer,
     ScoreFunction,
     optimize_code,
+    optimize_exhaustive,
     slice_code,
     SlicedEinsum,
     uniform_size_dict,
@@ -222,6 +224,48 @@ def test_optimize_code_treesa():
     tree = optimize_code(ixs, out, sizes, TreeSA.fast())
     assert tree is not None
     assert tree.is_binary()
+
+
+def test_optimize_code_exhaustive():
+    """Test optimize_code with ExhaustiveSearch."""
+    ixs = [[0, 1], [1, 2], [2, 3]]
+    out = [0, 3]
+    sizes = {0: 2, 1: 3, 2: 4, 3: 5}
+
+    tree = optimize_code(ixs, out, sizes, ExhaustiveSearch())
+    assert tree is not None
+    assert tree.is_binary()
+    assert tree.leaf_count() == 3
+    assert tree.to_dict()["eins"]["iy"] == out
+
+
+def test_optimize_exhaustive_helper():
+    """Test explicit optimize_exhaustive helper."""
+    ixs = [[0, 1], [1, 2]]
+    out = [0, 2]
+    sizes = {0: 2, 1: 3, 2: 5}
+
+    tree = optimize_exhaustive(ixs, out, sizes)
+    assert tree.is_binary()
+    assert tree.leaf_count() == 2
+
+
+def test_exhaustive_search_config_and_repr():
+    """Test ExhaustiveSearch configuration."""
+    opt = ExhaustiveSearch(verbose=True)
+    assert opt.verbose is True
+    assert "ExhaustiveSearch" in repr(opt)
+    assert "verbose=True" in repr(opt)
+
+
+def test_exhaustive_scope_error_becomes_value_error():
+    """Test exact-search unsupported scope error in Python."""
+    ixs = [[0, 0, 1], [1, 2], [2, 3]]
+    out = [3]
+    sizes = {0: 2, 1: 3, 2: 5, 3: 7}
+
+    with pytest.raises(ValueError, match="partial traces"):
+        optimize_code(ixs, out, sizes, ExhaustiveSearch())
 
 
 def test_optimize_code_treesa_configured():

--- a/omeco/src/exhaustive.rs
+++ b/omeco/src/exhaustive.rs
@@ -1,0 +1,517 @@
+//! Exact contraction-order optimizer using exhaustive dynamic programming.
+//!
+//! `ExhaustiveSearch` is intended for small tensor networks where the optimal
+//! total contraction FLOP count is more important than optimizer runtime.
+
+use crate::{EinCode, Label, NestedEinsum};
+use std::collections::{HashMap, HashSet};
+use thiserror::Error;
+
+type Mask = u128;
+
+/// Exact contraction-order optimizer.
+///
+/// This optimizer minimizes total FLOP count within each connected component.
+/// Disconnected components are then combined with outer products from smallest
+/// output size to largest.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct ExhaustiveSearch {
+    /// Print progress information during the search.
+    pub verbose: bool,
+}
+
+impl ExhaustiveSearch {
+    /// Create a new exhaustive optimizer.
+    pub fn new(verbose: bool) -> Self {
+        Self { verbose }
+    }
+}
+
+/// Errors reported by [`optimize_exhaustive`].
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum ExhaustiveSearchError {
+    /// The input has no tensors.
+    #[error("ExhaustiveSearch requires at least one tensor")]
+    EmptyInput,
+    /// The exact bitset implementation currently supports up to 128 tensors.
+    #[error("ExhaustiveSearch supports at most 128 tensors, got {0}")]
+    TooManyTensors(usize),
+    /// The exact bitset implementation currently supports up to 128 labels.
+    #[error("ExhaustiveSearch supports at most 128 unique labels, got {0}")]
+    TooManyLabels(usize),
+    /// An output label is not present in any input tensor.
+    #[error("output label {0} does not appear in the input tensors")]
+    InvalidOutputLabel(String),
+    /// A single tensor repeats a label, which would require a unary trace.
+    #[error(
+        "partial traces are not supported: label {label} appears more than once in tensor {tensor}"
+    )]
+    PartialTrace { tensor: usize, label: String },
+    /// A summed index appears in only one tensor, which would require a unary sum.
+    #[error("dangling summed indices are not supported: label {0} appears in only one tensor and is not an output label")]
+    DanglingSummedIndex(String),
+    /// A connected component could not be contracted under the supported scope.
+    #[error("could not construct a connected binary contraction tree")]
+    NoContractionTree,
+    /// The configured or inferred dimensions overflowed `usize`.
+    #[error("contraction cost overflowed usize")]
+    CostOverflow,
+}
+
+#[derive(Debug, Clone)]
+enum SearchTree {
+    Leaf(usize),
+    Node(Box<SearchTree>, Box<SearchTree>),
+}
+
+#[derive(Debug, Clone)]
+struct DpEntry {
+    cost: usize,
+    tree: SearchTree,
+}
+
+#[derive(Debug, Clone)]
+struct ComponentResult<L: Label> {
+    tensor_mask: Mask,
+    labels: Vec<L>,
+    tree: NestedEinsum<L>,
+    output_size: usize,
+}
+
+struct SearchContext<'a, L: Label> {
+    code: &'a EinCode<L>,
+    size_dict: &'a HashMap<L, usize>,
+    labels: Vec<L>,
+    label_tensor_masks: Vec<Mask>,
+    output_label_mask: Mask,
+    full_tensor_mask: Mask,
+}
+
+/// Optimize an [`EinCode`] with exact dynamic programming.
+pub fn optimize_exhaustive<L: Label>(
+    code: &EinCode<L>,
+    size_dict: &HashMap<L, usize>,
+    config: &ExhaustiveSearch,
+) -> Result<NestedEinsum<L>, ExhaustiveSearchError> {
+    let n = code.num_tensors();
+    if n == 0 {
+        return Err(ExhaustiveSearchError::EmptyInput);
+    }
+    if n > 128 {
+        return Err(ExhaustiveSearchError::TooManyTensors(n));
+    }
+
+    if n == 1 {
+        return Ok(NestedEinsum::leaf(0));
+    }
+    if n == 2 {
+        return Ok(NestedEinsum::node(
+            vec![NestedEinsum::leaf(0), NestedEinsum::leaf(1)],
+            code.clone(),
+        ));
+    }
+
+    validate_scope(code)?;
+    let ctx = SearchContext::new(code, size_dict)?;
+    let components = connected_components(&ctx);
+
+    if config.verbose {
+        eprintln!(
+            "ExhaustiveSearch: {} tensors, {} labels, {} connected component(s)",
+            n,
+            ctx.labels.len(),
+            components.len()
+        );
+    }
+
+    let mut results = Vec::with_capacity(components.len());
+    for component in components {
+        results.push(optimize_component(&ctx, component)?);
+    }
+
+    combine_components(&ctx, results)
+}
+
+impl<'a, L: Label> SearchContext<'a, L> {
+    fn new(
+        code: &'a EinCode<L>,
+        size_dict: &'a HashMap<L, usize>,
+    ) -> Result<Self, ExhaustiveSearchError> {
+        let labels = code.unique_labels();
+        if labels.len() > 128 {
+            return Err(ExhaustiveSearchError::TooManyLabels(labels.len()));
+        }
+
+        let label_to_pos: HashMap<L, usize> = labels
+            .iter()
+            .cloned()
+            .enumerate()
+            .map(|(i, label)| (label, i))
+            .collect();
+        let mut label_tensor_masks = vec![0; labels.len()];
+
+        for (tensor, ix) in code.ixs.iter().enumerate() {
+            let bit = bit(tensor);
+            let mut seen = HashSet::new();
+            for label in ix {
+                if seen.insert(label) {
+                    let pos = label_to_pos[label];
+                    label_tensor_masks[pos] |= bit;
+                }
+            }
+        }
+
+        let mut output_label_mask = 0;
+        for label in &code.iy {
+            let pos = label_to_pos
+                .get(label)
+                .copied()
+                .ok_or_else(|| ExhaustiveSearchError::InvalidOutputLabel(format!("{label:?}")))?;
+            output_label_mask |= bit(pos);
+        }
+
+        Ok(Self {
+            code,
+            size_dict,
+            labels,
+            label_tensor_masks,
+            output_label_mask,
+            full_tensor_mask: first_n_bits(code.num_tensors()),
+        })
+    }
+
+    fn open_label_mask(&self, tensor_mask: Mask) -> Mask {
+        let outside = self.full_tensor_mask & !tensor_mask;
+        let mut labels = 0;
+
+        for (label_pos, &label_tensors) in self.label_tensor_masks.iter().enumerate() {
+            if label_tensors & tensor_mask == 0 {
+                continue;
+            }
+
+            let is_output = self.output_label_mask & bit(label_pos) != 0;
+            let appears_outside = label_tensors & outside != 0;
+            if is_output || appears_outside {
+                labels |= bit(label_pos);
+            }
+        }
+
+        labels
+    }
+
+    fn labels_from_mask(&self, label_mask: Mask) -> Vec<L> {
+        self.labels
+            .iter()
+            .enumerate()
+            .filter_map(|(i, label)| {
+                if label_mask & bit(i) != 0 {
+                    Some(label.clone())
+                } else {
+                    None
+                }
+            })
+            .collect()
+    }
+
+    fn root_labels_for_mask(&self, tensor_mask: Mask) -> Vec<L> {
+        if tensor_mask == self.full_tensor_mask {
+            return self.code.iy.clone();
+        }
+
+        let open_mask = self.open_label_mask(tensor_mask);
+        self.code
+            .iy
+            .iter()
+            .filter(|label| {
+                self.labels
+                    .iter()
+                    .position(|candidate| candidate == *label)
+                    .is_some_and(|pos| open_mask & bit(pos) != 0)
+            })
+            .cloned()
+            .collect()
+    }
+
+    fn label_mask_size(&self, label_mask: Mask) -> Result<usize, ExhaustiveSearchError> {
+        let mut size = 1usize;
+        for (i, label) in self.labels.iter().enumerate() {
+            if label_mask & bit(i) == 0 {
+                continue;
+            }
+            let dim = self.size_dict.get(label).copied().unwrap_or(1);
+            size = size
+                .checked_mul(dim)
+                .ok_or(ExhaustiveSearchError::CostOverflow)?;
+        }
+        Ok(size)
+    }
+}
+
+fn validate_scope<L: Label>(code: &EinCode<L>) -> Result<(), ExhaustiveSearchError> {
+    let output_labels: HashSet<_> = code.iy.iter().cloned().collect();
+    let mut occurrence_counts: HashMap<L, usize> = HashMap::new();
+
+    for (tensor, ix) in code.ixs.iter().enumerate() {
+        let mut seen = HashSet::new();
+        for label in ix {
+            if !seen.insert(label.clone()) {
+                return Err(ExhaustiveSearchError::PartialTrace {
+                    tensor,
+                    label: format!("{label:?}"),
+                });
+            }
+        }
+
+        for label in seen {
+            *occurrence_counts.entry(label).or_insert(0) += 1;
+        }
+    }
+
+    for label in &code.iy {
+        if !occurrence_counts.contains_key(label) {
+            return Err(ExhaustiveSearchError::InvalidOutputLabel(format!(
+                "{label:?}"
+            )));
+        }
+    }
+
+    for (label, count) in occurrence_counts {
+        if count == 1 && !output_labels.contains(&label) {
+            return Err(ExhaustiveSearchError::DanglingSummedIndex(format!(
+                "{label:?}"
+            )));
+        }
+    }
+
+    Ok(())
+}
+
+fn connected_components<L: Label>(ctx: &SearchContext<'_, L>) -> Vec<Mask> {
+    let mut components = Vec::new();
+    let mut unvisited = ctx.full_tensor_mask;
+
+    while unvisited != 0 {
+        let start = unvisited & unvisited.wrapping_neg();
+        let mut component = 0;
+        let mut frontier = start;
+        unvisited &= !start;
+
+        while frontier != 0 {
+            let tensor_bit = frontier & frontier.wrapping_neg();
+            frontier &= !tensor_bit;
+            component |= tensor_bit;
+
+            let mut neighbors = 0;
+            for &label_tensors in &ctx.label_tensor_masks {
+                if label_tensors & tensor_bit != 0 {
+                    neighbors |= label_tensors;
+                }
+            }
+
+            let new_neighbors = neighbors & unvisited;
+            frontier |= new_neighbors;
+            unvisited &= !new_neighbors;
+        }
+
+        components.push(component);
+    }
+
+    components
+}
+
+fn optimize_component<L: Label>(
+    ctx: &SearchContext<'_, L>,
+    component: Mask,
+) -> Result<ComponentResult<L>, ExhaustiveSearchError> {
+    if component.count_ones() == 1 {
+        let tensor = singleton_index(component);
+        let labels = ctx.root_labels_for_mask(component);
+        let output_size = ctx.label_mask_size(ctx.open_label_mask(component))?;
+        return Ok(ComponentResult {
+            tensor_mask: component,
+            labels,
+            tree: NestedEinsum::leaf(tensor),
+            output_size,
+        });
+    }
+
+    let component_size = component.count_ones() as usize;
+    let mut by_size: Vec<HashMap<Mask, DpEntry>> =
+        (0..=component_size).map(|_| HashMap::new()).collect();
+
+    for tensor in bits(component) {
+        let mask = bit(tensor);
+        by_size[1].insert(
+            mask,
+            DpEntry {
+                cost: 0,
+                tree: SearchTree::Leaf(tensor),
+            },
+        );
+    }
+
+    for size in 2..=component_size {
+        for subset in submasks_with_size(component, size) {
+            let mut best: Option<DpEntry> = None;
+            let anchor = subset & subset.wrapping_neg();
+            let mut left = (subset - 1) & subset;
+
+            while left != 0 {
+                let right = subset ^ left;
+                if right != 0 && left & anchor != 0 {
+                    let left_size = left.count_ones() as usize;
+                    let right_size = right.count_ones() as usize;
+
+                    if let (Some(left_entry), Some(right_entry)) = (
+                        by_size[left_size].get(&left),
+                        by_size[right_size].get(&right),
+                    ) {
+                        let shared_labels = ctx.open_label_mask(left) & ctx.open_label_mask(right);
+                        if shared_labels != 0 {
+                            let merge_label_mask =
+                                ctx.open_label_mask(left) | ctx.open_label_mask(right);
+                            let merge_cost = ctx.label_mask_size(merge_label_mask)?;
+                            let cost = left_entry
+                                .cost
+                                .checked_add(right_entry.cost)
+                                .and_then(|c| c.checked_add(merge_cost))
+                                .ok_or(ExhaustiveSearchError::CostOverflow)?;
+
+                            if best.as_ref().map_or(true, |entry| cost < entry.cost) {
+                                best = Some(DpEntry {
+                                    cost,
+                                    tree: SearchTree::Node(
+                                        Box::new(left_entry.tree.clone()),
+                                        Box::new(right_entry.tree.clone()),
+                                    ),
+                                });
+                            }
+                        }
+                    }
+                }
+                left = (left - 1) & subset;
+            }
+
+            if let Some(entry) = best {
+                by_size[size].insert(subset, entry);
+            }
+        }
+    }
+
+    let entry = by_size[component_size]
+        .get(&component)
+        .ok_or(ExhaustiveSearchError::NoContractionTree)?;
+    let labels = ctx.root_labels_for_mask(component);
+    let tree = build_nested(ctx, &entry.tree, component, true);
+    let output_size = ctx.label_mask_size(ctx.open_label_mask(component))?;
+
+    Ok(ComponentResult {
+        tensor_mask: component,
+        labels,
+        tree,
+        output_size,
+    })
+}
+
+fn build_nested<L: Label>(
+    ctx: &SearchContext<'_, L>,
+    tree: &SearchTree,
+    tensor_mask: Mask,
+    force_root_labels: bool,
+) -> NestedEinsum<L> {
+    match tree {
+        SearchTree::Leaf(tensor) => NestedEinsum::leaf(*tensor),
+        SearchTree::Node(left, right) => {
+            let left_mask = tree_tensor_mask(left);
+            let right_mask = tensor_mask ^ left_mask;
+            let left_nested = build_nested(ctx, left, left_mask, false);
+            let right_nested = build_nested(ctx, right, right_mask, false);
+            let left_labels = left_nested.output_labels(&ctx.code.ixs);
+            let right_labels = right_nested.output_labels(&ctx.code.ixs);
+            let output = if force_root_labels {
+                ctx.root_labels_for_mask(tensor_mask)
+            } else {
+                ctx.labels_from_mask(ctx.open_label_mask(tensor_mask))
+            };
+
+            NestedEinsum::node(
+                vec![left_nested, right_nested],
+                EinCode::new(vec![left_labels, right_labels], output),
+            )
+        }
+    }
+}
+
+fn combine_components<L: Label>(
+    ctx: &SearchContext<'_, L>,
+    mut results: Vec<ComponentResult<L>>,
+) -> Result<NestedEinsum<L>, ExhaustiveSearchError> {
+    if results.is_empty() {
+        return Err(ExhaustiveSearchError::NoContractionTree);
+    }
+
+    while results.len() > 1 {
+        results.sort_by_key(|result| result.output_size);
+        let left = results.remove(0);
+        let right = results.remove(0);
+        let tensor_mask = left.tensor_mask | right.tensor_mask;
+        let output = if tensor_mask == ctx.full_tensor_mask {
+            ctx.code.iy.clone()
+        } else {
+            ctx.root_labels_for_mask(tensor_mask)
+        };
+        let output_size = ctx.label_mask_size(ctx.open_label_mask(tensor_mask))?;
+        let tree = NestedEinsum::node(
+            vec![left.tree, right.tree],
+            EinCode::new(vec![left.labels, right.labels], output.clone()),
+        );
+
+        results.push(ComponentResult {
+            tensor_mask,
+            labels: output,
+            tree,
+            output_size,
+        });
+    }
+
+    Ok(results.pop().unwrap().tree)
+}
+
+fn tree_tensor_mask(tree: &SearchTree) -> Mask {
+    match tree {
+        SearchTree::Leaf(tensor) => bit(*tensor),
+        SearchTree::Node(left, right) => tree_tensor_mask(left) | tree_tensor_mask(right),
+    }
+}
+
+fn first_n_bits(n: usize) -> Mask {
+    if n == 128 {
+        Mask::MAX
+    } else {
+        (1u128 << n) - 1
+    }
+}
+
+fn bit(pos: usize) -> Mask {
+    1u128 << pos
+}
+
+fn singleton_index(mask: Mask) -> usize {
+    mask.trailing_zeros() as usize
+}
+
+fn bits(mask: Mask) -> impl Iterator<Item = usize> {
+    (0..128).filter(move |&i| mask & bit(i) != 0)
+}
+
+fn submasks_with_size(mask: Mask, size: usize) -> impl Iterator<Item = Mask> {
+    let mut submasks = Vec::new();
+    let mut submask = mask;
+    while submask != 0 {
+        if submask.count_ones() as usize == size {
+            submasks.push(submask);
+        }
+        submask = (submask - 1) & mask;
+    }
+    submasks.into_iter()
+}

--- a/omeco/src/exhaustive.rs
+++ b/omeco/src/exhaustive.rs
@@ -101,8 +101,19 @@ pub fn optimize_exhaustive<L: Label>(
         return Err(ExhaustiveSearchError::TooManyTensors(n));
     }
 
+    if n <= 2 {
+        validate_output_labels(code)?;
+    }
+
     if n == 1 {
-        return Ok(NestedEinsum::leaf(0));
+        if code.iy == code.ixs[0] {
+            return Ok(NestedEinsum::leaf(0));
+        }
+
+        return Ok(NestedEinsum::node(
+            vec![NestedEinsum::leaf(0)],
+            code.clone(),
+        ));
     }
     if n == 2 {
         return Ok(NestedEinsum::node(
@@ -247,7 +258,23 @@ impl<'a, L: Label> SearchContext<'a, L> {
     }
 }
 
+fn validate_output_labels<L: Label>(code: &EinCode<L>) -> Result<(), ExhaustiveSearchError> {
+    let input_labels: HashSet<_> = code.ixs.iter().flatten().cloned().collect();
+
+    for label in &code.iy {
+        if !input_labels.contains(label) {
+            return Err(ExhaustiveSearchError::InvalidOutputLabel(format!(
+                "{label:?}"
+            )));
+        }
+    }
+
+    Ok(())
+}
+
 fn validate_scope<L: Label>(code: &EinCode<L>) -> Result<(), ExhaustiveSearchError> {
+    validate_output_labels(code)?;
+
     let output_labels: HashSet<_> = code.iy.iter().cloned().collect();
     let mut occurrence_counts: HashMap<L, usize> = HashMap::new();
 
@@ -264,14 +291,6 @@ fn validate_scope<L: Label>(code: &EinCode<L>) -> Result<(), ExhaustiveSearchErr
 
         for label in seen {
             *occurrence_counts.entry(label).or_insert(0) += 1;
-        }
-    }
-
-    for label in &code.iy {
-        if !occurrence_counts.contains_key(label) {
-            return Err(ExhaustiveSearchError::InvalidOutputLabel(format!(
-                "{label:?}"
-            )));
         }
     }
 
@@ -505,13 +524,204 @@ fn bits(mask: Mask) -> impl Iterator<Item = usize> {
 }
 
 fn submasks_with_size(mask: Mask, size: usize) -> impl Iterator<Item = Mask> {
-    let mut submasks = Vec::new();
     let mut submask = mask;
-    while submask != 0 {
-        if submask.count_ones() as usize == size {
-            submasks.push(submask);
+
+    std::iter::from_fn(move || {
+        while submask != 0 {
+            let current = submask;
+            submask = (submask - 1) & mask;
+
+            if current.count_ones() as usize == size {
+                return Some(current);
+            }
         }
-        submask = (submask - 1) & mask;
+
+        None
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sizes(values: &[(usize, usize)]) -> HashMap<usize, usize> {
+        values.iter().copied().collect()
     }
-    submasks.into_iter()
+
+    #[test]
+    fn exhaustive_search_new_sets_verbose() {
+        assert!(ExhaustiveSearch::new(true).verbose);
+    }
+
+    #[test]
+    fn validates_empty_and_size_limit_errors() {
+        let empty = EinCode::<usize>::new(vec![], vec![]);
+        assert_eq!(
+            optimize_exhaustive(&empty, &HashMap::new(), &ExhaustiveSearch::default()).unwrap_err(),
+            ExhaustiveSearchError::EmptyInput
+        );
+
+        let too_many_tensors = EinCode::new(vec![vec![0usize]; 129], vec![]);
+        assert_eq!(
+            optimize_exhaustive(
+                &too_many_tensors,
+                &HashMap::new(),
+                &ExhaustiveSearch::default()
+            )
+            .unwrap_err(),
+            ExhaustiveSearchError::TooManyTensors(129)
+        );
+
+        let large_tensor: Vec<_> = (0usize..129).collect();
+        let too_many_labels = EinCode::new(
+            vec![large_tensor.clone(), vec![0], vec![1]],
+            large_tensor.clone(),
+        );
+        assert_eq!(
+            optimize_exhaustive(
+                &too_many_labels,
+                &uniform_sizes(&large_tensor),
+                &ExhaustiveSearch::default()
+            )
+            .unwrap_err(),
+            ExhaustiveSearchError::TooManyLabels(129)
+        );
+    }
+
+    #[test]
+    fn invalid_output_is_rejected_for_trivial_inputs() {
+        let one = EinCode::new(vec![vec![0usize]], vec![1]);
+        let two = EinCode::new(vec![vec![0usize], vec![0]], vec![1]);
+
+        assert!(matches!(
+            optimize_exhaustive(
+                &one,
+                &sizes(&[(0, 2), (1, 3)]),
+                &ExhaustiveSearch::default()
+            ),
+            Err(ExhaustiveSearchError::InvalidOutputLabel(_))
+        ));
+        assert!(matches!(
+            optimize_exhaustive(
+                &two,
+                &sizes(&[(0, 2), (1, 3)]),
+                &ExhaustiveSearch::default()
+            ),
+            Err(ExhaustiveSearchError::InvalidOutputLabel(_))
+        ));
+    }
+
+    #[test]
+    fn single_tensor_output_reorder_uses_unary_node() {
+        let code = EinCode::new(vec![vec![0usize, 1]], vec![1, 0]);
+        let nested = optimize_exhaustive(
+            &code,
+            &sizes(&[(0, 2), (1, 3)]),
+            &ExhaustiveSearch::default(),
+        )
+        .unwrap();
+
+        match nested {
+            NestedEinsum::Node { args, eins } => {
+                assert_eq!(args.len(), 1);
+                assert_eq!(eins.iy, vec![1, 0]);
+            }
+            NestedEinsum::Leaf { .. } => panic!("output reorder needs a unary node"),
+        }
+    }
+
+    #[test]
+    fn verbose_search_runs() {
+        let code = EinCode::new(vec![vec![0usize, 1], vec![1, 2], vec![2, 3]], vec![0, 3]);
+        let size_dict = sizes(&[(0, 2), (1, 3), (2, 5), (3, 7)]);
+
+        let nested = optimize_exhaustive(&code, &size_dict, &ExhaustiveSearch::new(true)).unwrap();
+
+        assert!(nested.is_binary());
+    }
+
+    #[test]
+    fn oversized_dimensions_report_overflow() {
+        let code = EinCode::new(vec![vec![0usize, 1], vec![1, 2], vec![2, 3]], vec![0, 3]);
+        let size_dict = sizes(&[(0, usize::MAX), (1, 2), (2, 2), (3, 2)]);
+
+        assert_eq!(
+            optimize_exhaustive(&code, &size_dict, &ExhaustiveSearch::default()).unwrap_err(),
+            ExhaustiveSearchError::CostOverflow
+        );
+    }
+
+    #[test]
+    fn validates_scope_errors_with_specific_variants() {
+        let partial_trace = EinCode::new(vec![vec![0usize, 0, 1], vec![1, 2], vec![2, 3]], vec![3]);
+        assert_eq!(
+            validate_scope(&partial_trace).unwrap_err(),
+            ExhaustiveSearchError::PartialTrace {
+                tensor: 0,
+                label: "0".to_string(),
+            }
+        );
+
+        let dangling_sum = EinCode::new(vec![vec![0usize, 1], vec![1, 2], vec![2, 3]], vec![0, 2]);
+        assert_eq!(
+            validate_scope(&dangling_sum).unwrap_err(),
+            ExhaustiveSearchError::DanglingSummedIndex("3".to_string())
+        );
+    }
+
+    #[test]
+    fn singleton_component_is_combined_with_other_components() {
+        let code = EinCode::new(
+            vec![vec![0usize], vec![1, 2], vec![2, 3], vec![4, 5], vec![5, 6]],
+            vec![0, 1, 3, 4, 6],
+        );
+        let size_dict = sizes(&[(0, 2), (1, 3), (2, 5), (3, 7), (4, 11), (5, 13), (6, 17)]);
+
+        let nested = optimize_exhaustive(&code, &size_dict, &ExhaustiveSearch::default()).unwrap();
+
+        assert!(nested.is_binary());
+        assert_eq!(nested.leaf_count(), 5);
+        assert_eq!(nested.output_labels(&code.ixs), code.iy);
+    }
+
+    #[test]
+    fn private_helpers_cover_boundary_cases() {
+        assert_eq!(first_n_bits(128), Mask::MAX);
+        assert_eq!(singleton_index(bit(17)), 17);
+
+        let submasks: Vec<_> = submasks_with_size(0b1111, 2).collect();
+        assert_eq!(submasks.len(), 6);
+        assert!(submasks.contains(&0b0011));
+        assert!(submasks.contains(&0b1100));
+    }
+
+    #[test]
+    fn combine_components_rejects_empty_results() {
+        let code = EinCode::new(vec![vec![0usize, 1], vec![1, 2], vec![2, 3]], vec![0, 3]);
+        let size_dict = sizes(&[(0, 2), (1, 3), (2, 5), (3, 7)]);
+        let ctx = SearchContext::new(&code, &size_dict).unwrap();
+
+        assert_eq!(
+            combine_components(&ctx, Vec::new()).unwrap_err(),
+            ExhaustiveSearchError::NoContractionTree
+        );
+    }
+
+    #[test]
+    fn private_helpers_cover_defensive_branches() {
+        let disconnected = EinCode::new(vec![vec![0usize], vec![1]], vec![0, 1]);
+        let size_dict = sizes(&[(0, 2), (1, 3)]);
+        let ctx = SearchContext::new(&disconnected, &size_dict).unwrap();
+
+        assert_eq!(ctx.open_label_mask(0), 0);
+        assert_eq!(ctx.label_mask_size(0).unwrap(), 1);
+        assert_eq!(
+            optimize_component(&ctx, bit(0) | bit(1)).unwrap_err(),
+            ExhaustiveSearchError::NoContractionTree
+        );
+    }
+
+    fn uniform_sizes(labels: &[usize]) -> HashMap<usize, usize> {
+        labels.iter().copied().map(|label| (label, 2)).collect()
+    }
 }

--- a/omeco/src/exhaustive.rs
+++ b/omeco/src/exhaustive.rs
@@ -127,12 +127,9 @@ pub fn optimize_exhaustive<L: Label>(
     let components = connected_components(&ctx);
 
     if config.verbose {
-        eprintln!(
-            "ExhaustiveSearch: {} tensors, {} labels, {} connected component(s)",
-            n,
-            ctx.labels.len(),
-            components.len()
-        );
+        let label_count = ctx.labels.len();
+        let component_count = components.len();
+        eprintln!("ExhaustiveSearch: {n} tensors, {label_count} labels, {component_count} connected component(s)");
     }
 
     let mut results = Vec::with_capacity(components.len());
@@ -181,14 +178,16 @@ impl<'a, L: Label> SearchContext<'a, L> {
             output_label_mask |= bit(pos);
         }
 
-        Ok(Self {
+        let full_tensor_mask = first_n_bits(code.num_tensors());
+        let ctx = Self {
             code,
             size_dict,
             labels,
             label_tensor_masks,
             output_label_mask,
-            full_tensor_mask: first_n_bits(code.num_tensors()),
-        })
+            full_tensor_mask,
+        };
+        Ok(ctx)
     }
 
     fn open_label_mask(&self, tensor_mask: Mask) -> Mask {
@@ -196,14 +195,12 @@ impl<'a, L: Label> SearchContext<'a, L> {
         let mut labels = 0;
 
         for (label_pos, &label_tensors) in self.label_tensor_masks.iter().enumerate() {
-            if label_tensors & tensor_mask == 0 {
-                continue;
-            }
-
-            let is_output = self.output_label_mask & bit(label_pos) != 0;
-            let appears_outside = label_tensors & outside != 0;
-            if is_output || appears_outside {
-                labels |= bit(label_pos);
+            if label_tensors & tensor_mask != 0 {
+                let is_output = self.output_label_mask & bit(label_pos) != 0;
+                let appears_outside = label_tensors & outside != 0;
+                if is_output || appears_outside {
+                    labels |= bit(label_pos);
+                }
             }
         }
 
@@ -229,30 +226,30 @@ impl<'a, L: Label> SearchContext<'a, L> {
             return self.code.iy.clone();
         }
 
+        let mut labels = Vec::new();
         let open_mask = self.open_label_mask(tensor_mask);
-        self.code
-            .iy
-            .iter()
-            .filter(|label| {
-                self.labels
-                    .iter()
-                    .position(|candidate| candidate == *label)
-                    .is_some_and(|pos| open_mask & bit(pos) != 0)
-            })
-            .cloned()
-            .collect()
+        for label in &self.code.iy {
+            let is_open = self
+                .labels
+                .iter()
+                .position(|candidate| candidate == label)
+                .is_some_and(|pos| open_mask & bit(pos) != 0);
+            if is_open {
+                labels.push(label.clone());
+            }
+        }
+        labels
     }
 
     fn label_mask_size(&self, label_mask: Mask) -> Result<usize, ExhaustiveSearchError> {
         let mut size = 1usize;
         for (i, label) in self.labels.iter().enumerate() {
-            if label_mask & bit(i) == 0 {
-                continue;
+            if label_mask & bit(i) != 0 {
+                let dim = self.size_dict.get(label).copied().unwrap_or(1);
+                size = size
+                    .checked_mul(dim)
+                    .ok_or(ExhaustiveSearchError::CostOverflow)?;
             }
-            let dim = self.size_dict.get(label).copied().unwrap_or(1);
-            size = size
-                .checked_mul(dim)
-                .ok_or(ExhaustiveSearchError::CostOverflow)?;
         }
         Ok(size)
     }
@@ -282,10 +279,8 @@ fn validate_scope<L: Label>(code: &EinCode<L>) -> Result<(), ExhaustiveSearchErr
         let mut seen = HashSet::new();
         for label in ix {
             if !seen.insert(label.clone()) {
-                return Err(ExhaustiveSearchError::PartialTrace {
-                    tensor,
-                    label: format!("{label:?}"),
-                });
+                let label = format!("{label:?}");
+                return Err(ExhaustiveSearchError::PartialTrace { tensor, label });
             }
         }
 
@@ -345,28 +340,30 @@ fn optimize_component<L: Label>(
     if component.count_ones() == 1 {
         let tensor = singleton_index(component);
         let labels = ctx.root_labels_for_mask(component);
+        let tree = NestedEinsum::leaf(tensor);
         let output_size = ctx.label_mask_size(ctx.open_label_mask(component))?;
-        return Ok(ComponentResult {
+        let result = ComponentResult {
             tensor_mask: component,
             labels,
-            tree: NestedEinsum::leaf(tensor),
+            tree,
             output_size,
-        });
+        };
+        return Ok(result);
     }
 
     let component_size = component.count_ones() as usize;
-    let mut by_size: Vec<HashMap<Mask, DpEntry>> =
-        (0..=component_size).map(|_| HashMap::new()).collect();
+    let mut by_size = Vec::with_capacity(component_size + 1);
+    for _ in 0..=component_size {
+        by_size.push(HashMap::new());
+    }
 
     for tensor in bits(component) {
         let mask = bit(tensor);
-        by_size[1].insert(
-            mask,
-            DpEntry {
-                cost: 0,
-                tree: SearchTree::Leaf(tensor),
-            },
-        );
+        let entry = DpEntry {
+            cost: 0,
+            tree: SearchTree::Leaf(tensor),
+        };
+        by_size[1].insert(mask, entry);
     }
 
     for size in 2..=component_size {
@@ -385,25 +382,26 @@ fn optimize_component<L: Label>(
                         by_size[left_size].get(&left),
                         by_size[right_size].get(&right),
                     ) {
-                        let shared_labels = ctx.open_label_mask(left) & ctx.open_label_mask(right);
+                        let left_open_labels = ctx.open_label_mask(left);
+                        let right_open_labels = ctx.open_label_mask(right);
+                        let shared_labels = left_open_labels & right_open_labels;
                         if shared_labels != 0 {
-                            let merge_label_mask =
-                                ctx.open_label_mask(left) | ctx.open_label_mask(right);
+                            let merge_label_mask = left_open_labels | right_open_labels;
                             let merge_cost = ctx.label_mask_size(merge_label_mask)?;
-                            let cost = left_entry
+                            let cost_after_left = left_entry
                                 .cost
                                 .checked_add(right_entry.cost)
-                                .and_then(|c| c.checked_add(merge_cost))
+                                .ok_or(ExhaustiveSearchError::CostOverflow)?;
+                            let cost = cost_after_left
+                                .checked_add(merge_cost)
                                 .ok_or(ExhaustiveSearchError::CostOverflow)?;
 
                             if best.as_ref().map_or(true, |entry| cost < entry.cost) {
-                                best = Some(DpEntry {
-                                    cost,
-                                    tree: SearchTree::Node(
-                                        Box::new(left_entry.tree.clone()),
-                                        Box::new(right_entry.tree.clone()),
-                                    ),
-                                });
+                                let tree = SearchTree::Node(
+                                    Box::new(left_entry.tree.clone()),
+                                    Box::new(right_entry.tree.clone()),
+                                );
+                                best = Some(DpEntry { cost, tree });
                             }
                         }
                     }
@@ -485,12 +483,13 @@ fn combine_components<L: Label>(
             EinCode::new(vec![left.labels, right.labels], output.clone()),
         );
 
-        results.push(ComponentResult {
+        let result = ComponentResult {
             tensor_mask,
             labels: output,
             tree,
             output_size,
-        });
+        };
+        results.push(result);
     }
 
     Ok(results.pop().unwrap().tree)

--- a/omeco/src/exhaustive_tests.rs
+++ b/omeco/src/exhaustive_tests.rs
@@ -1,0 +1,323 @@
+use crate::complexity::nested_flop;
+use crate::test_utils::{execute_nested, tensors_approx_equal, NaiveContractor};
+use crate::{
+    optimize_code, optimize_exhaustive, EinCode, ExhaustiveSearch, GreedyMethod, NestedEinsum,
+};
+use std::collections::{HashMap, HashSet};
+
+#[derive(Debug, Clone)]
+enum TestTree {
+    Leaf(usize),
+    Node(Box<TestTree>, Box<TestTree>),
+}
+
+fn sizes(values: &[(usize, usize)]) -> HashMap<usize, usize> {
+    values.iter().copied().collect()
+}
+
+fn set_of_tree(tree: &TestTree) -> HashSet<usize> {
+    match tree {
+        TestTree::Leaf(i) => HashSet::from([*i]),
+        TestTree::Node(left, right) => {
+            let mut set = set_of_tree(left);
+            set.extend(set_of_tree(right));
+            set
+        }
+    }
+}
+
+fn open_labels(ixs: &[Vec<usize>], iy: &[usize], tensors: &HashSet<usize>) -> Vec<usize> {
+    let output: HashSet<_> = iy.iter().copied().collect();
+    let mut result = Vec::new();
+    let mut seen = HashSet::new();
+
+    for &tensor in tensors {
+        for &label in &ixs[tensor] {
+            if seen.contains(&label) {
+                continue;
+            }
+
+            let appears_outside = ixs
+                .iter()
+                .enumerate()
+                .any(|(i, ix)| !tensors.contains(&i) && ix.contains(&label));
+            if output.contains(&label) || appears_outside {
+                seen.insert(label);
+                result.push(label);
+            }
+        }
+    }
+
+    result.sort_unstable();
+    result
+}
+
+fn test_tree_to_nested(
+    tree: &TestTree,
+    ixs: &[Vec<usize>],
+    iy: &[usize],
+    full_set: &HashSet<usize>,
+) -> NestedEinsum<usize> {
+    match tree {
+        TestTree::Leaf(i) => NestedEinsum::leaf(*i),
+        TestTree::Node(left, right) => {
+            let left_nested = test_tree_to_nested(left, ixs, iy, full_set);
+            let right_nested = test_tree_to_nested(right, ixs, iy, full_set);
+            let left_set = set_of_tree(left);
+            let right_set = set_of_tree(right);
+            let mut merged = left_set.clone();
+            merged.extend(right_set);
+
+            let left_labels = left_nested.output_labels(ixs);
+            let right_labels = right_nested.output_labels(ixs);
+            let output = if &merged == full_set {
+                iy.to_vec()
+            } else {
+                open_labels(ixs, iy, &merged)
+            };
+
+            NestedEinsum::node(
+                vec![left_nested, right_nested],
+                EinCode::new(vec![left_labels, right_labels], output),
+            )
+        }
+    }
+}
+
+fn all_binary_trees(leaves: &[usize]) -> Vec<TestTree> {
+    if leaves.len() == 1 {
+        return vec![TestTree::Leaf(leaves[0])];
+    }
+
+    let first = leaves[0];
+    let rest = &leaves[1..];
+    let mut trees = Vec::new();
+
+    for mask in 0usize..(1usize << rest.len()) {
+        let mut left = vec![first];
+        let mut right = Vec::new();
+
+        for (bit, &leaf) in rest.iter().enumerate() {
+            if (mask & (1usize << bit)) == 0 {
+                left.push(leaf);
+            } else {
+                right.push(leaf);
+            }
+        }
+
+        if right.is_empty() {
+            continue;
+        }
+
+        for left_tree in all_binary_trees(&left) {
+            for right_tree in all_binary_trees(&right) {
+                trees.push(TestTree::Node(
+                    Box::new(left_tree.clone()),
+                    Box::new(right_tree),
+                ));
+            }
+        }
+    }
+
+    trees
+}
+
+fn brute_force_min_flop(code: &EinCode<usize>, size_dict: &HashMap<usize, usize>) -> usize {
+    let leaves: Vec<_> = (0..code.num_tensors()).collect();
+    let full_set: HashSet<_> = leaves.iter().copied().collect();
+
+    all_binary_trees(&leaves)
+        .iter()
+        .map(|tree| {
+            let nested = test_tree_to_nested(tree, &code.ixs, &code.iy, &full_set);
+            nested_flop(&nested, size_dict)
+        })
+        .min()
+        .unwrap()
+}
+
+fn assert_exhaustive_is_optimal(code: EinCode<usize>, size_dict: HashMap<usize, usize>) {
+    let nested = optimize_exhaustive(&code, &size_dict, &ExhaustiveSearch::default()).unwrap();
+    assert!(nested.is_binary());
+    assert_eq!(
+        nested_flop(&nested, &size_dict),
+        brute_force_min_flop(&code, &size_dict)
+    );
+}
+
+#[test]
+fn exhaustive_matches_bruteforce_on_five_tensor_network() {
+    let code = EinCode::new(
+        vec![
+            vec![0, 1],
+            vec![0, 2, 3],
+            vec![1, 2, 4, 5],
+            vec![4],
+            vec![3, 5],
+        ],
+        vec![],
+    );
+    let size_dict = sizes(&[(0, 2), (1, 4), (2, 8), (3, 16), (4, 32), (5, 64)]);
+
+    assert_exhaustive_is_optimal(code, size_dict);
+}
+
+#[test]
+fn exhaustive_finds_matrix_chain_optimum() {
+    let code = EinCode::new(vec![vec![0, 1], vec![1, 2], vec![2, 3]], vec![0, 3]);
+    let size_dict = sizes(&[(0, 2), (1, 3), (2, 4), (3, 5)]);
+
+    assert_exhaustive_is_optimal(code, size_dict);
+}
+
+#[test]
+fn exhaustive_preserves_numerical_result() {
+    let code = EinCode::new(
+        vec![
+            vec![0, 1],
+            vec![0, 2, 3],
+            vec![1, 2, 4, 5],
+            vec![4],
+            vec![3, 5],
+        ],
+        vec![],
+    );
+    let size_dict = sizes(&[(0, 2), (1, 2), (2, 2), (3, 2), (4, 2), (5, 2)]);
+    let exact = optimize_exhaustive(&code, &size_dict, &ExhaustiveSearch::default()).unwrap();
+    let greedy = optimize_code(&code, &size_dict, &GreedyMethod::default()).unwrap();
+
+    let mut contractor = NaiveContractor::new();
+    for (tensor, labels) in code.ixs.iter().enumerate() {
+        contractor.add_tensor(
+            tensor,
+            labels.iter().map(|label| size_dict[label]).collect(),
+        );
+    }
+    let label_map: HashMap<_, _> = code
+        .unique_labels()
+        .into_iter()
+        .map(|label| (label, label))
+        .collect();
+
+    let mut exact_contractor = contractor.clone();
+    let exact_idx = execute_nested(&exact, &mut exact_contractor, &label_map);
+    let greedy_idx = execute_nested(&greedy, &mut contractor, &label_map);
+    let exact_result = exact_contractor.get_tensor(exact_idx).unwrap();
+    let greedy_result = contractor.get_tensor(greedy_idx).unwrap();
+
+    assert!(tensors_approx_equal(
+        exact_result,
+        greedy_result,
+        1e-9,
+        1e-12
+    ));
+}
+
+#[test]
+fn exhaustive_preserves_root_output_order() {
+    let code = EinCode::new(vec![vec![0, 1], vec![1, 2], vec![2, 3]], vec![3, 0]);
+    let size_dict = sizes(&[(0, 2), (1, 3), (2, 4), (3, 5)]);
+    let nested = optimize_exhaustive(&code, &size_dict, &ExhaustiveSearch::default()).unwrap();
+
+    assert_eq!(nested.output_labels(&code.ixs), vec![3, 0]);
+}
+
+#[test]
+fn exhaustive_combines_disconnected_components_by_outer_product() {
+    let code = EinCode::new(
+        vec![vec![0, 1], vec![1, 2], vec![3, 4], vec![4, 5]],
+        vec![0, 2, 3, 5],
+    );
+    let size_dict = sizes(&[(0, 2), (1, 3), (2, 5), (3, 7), (4, 11), (5, 13)]);
+
+    assert_exhaustive_is_optimal(code, size_dict);
+}
+
+#[test]
+fn exhaustive_handles_trivial_one_and_two_tensor_inputs() {
+    let one = EinCode::new(vec![vec![0, 1]], vec![0, 1]);
+    let two = EinCode::new(vec![vec![0, 1], vec![1, 2]], vec![0, 2]);
+    let size_dict = sizes(&[(0, 2), (1, 3), (2, 5)]);
+
+    let one_nested = optimize_exhaustive(&one, &size_dict, &ExhaustiveSearch::default()).unwrap();
+    let two_nested = optimize_exhaustive(&two, &size_dict, &ExhaustiveSearch::default()).unwrap();
+
+    assert_eq!(one_nested.leaf_count(), 1);
+    assert_eq!(two_nested.leaf_count(), 2);
+    assert_eq!(two_nested.output_labels(&two.ixs), two.iy);
+}
+
+#[test]
+fn exhaustive_supports_hyperedges_summed_out() {
+    let code = EinCode::new(vec![vec![0, 1], vec![0, 2], vec![0, 3]], vec![1, 2, 3]);
+    let size_dict = sizes(&[(0, 5), (1, 2), (2, 3), (3, 7)]);
+
+    assert_exhaustive_is_optimal(code, size_dict);
+}
+
+#[test]
+fn exhaustive_supports_batch_diagonal_output_indices() {
+    let code = EinCode::new(vec![vec![0, 1], vec![0, 2], vec![2, 3]], vec![0, 1, 3]);
+    let size_dict = sizes(&[(0, 2), (1, 3), (2, 5), (3, 7)]);
+
+    assert_exhaustive_is_optimal(code, size_dict);
+}
+
+#[test]
+fn exhaustive_handles_dimension_one_contracted_indices() {
+    let code = EinCode::new(
+        vec![vec![0, 1], vec![1, 2], vec![2, 3], vec![3, 4]],
+        vec![0, 4],
+    );
+    let size_dict = sizes(&[(0, 3), (1, 1), (2, 5), (3, 1), (4, 7)]);
+
+    assert_exhaustive_is_optimal(code, size_dict);
+}
+
+#[test]
+fn exhaustive_handles_all_dimension_one_indices() {
+    let code = EinCode::new(vec![vec![0, 1], vec![1, 2], vec![2, 3]], vec![0, 3]);
+    let size_dict = sizes(&[(0, 1), (1, 1), (2, 1), (3, 1)]);
+
+    assert_exhaustive_is_optimal(code, size_dict);
+}
+
+#[test]
+fn exhaustive_handles_dimension_one_output_indices() {
+    let code = EinCode::new(vec![vec![0, 1], vec![1, 2], vec![2, 3]], vec![0, 3]);
+    let size_dict = sizes(&[(0, 1), (1, 4), (2, 1), (3, 1)]);
+
+    assert_exhaustive_is_optimal(code, size_dict);
+}
+
+#[test]
+fn exhaustive_reports_scope_errors_for_partial_trace_and_dangling_sums() {
+    let partial_trace = EinCode::new(vec![vec![0, 0, 1], vec![1, 2], vec![2, 3]], vec![3]);
+    let dangling_sum = EinCode::new(vec![vec![0, 1], vec![1, 2], vec![3, 4]], vec![0, 2]);
+    let size_dict = sizes(&[(0, 2), (1, 3), (2, 5), (3, 7), (4, 11)]);
+
+    assert!(optimize_exhaustive(&partial_trace, &size_dict, &ExhaustiveSearch::default()).is_err());
+    assert!(optimize_exhaustive(&dangling_sum, &size_dict, &ExhaustiveSearch::default()).is_err());
+}
+
+#[test]
+fn exhaustive_supports_char_labels_through_optimizer_trait() {
+    let code = EinCode::new(
+        vec![vec!['i', 'j'], vec!['j', 'k'], vec!['k', 'l']],
+        vec!['i', 'l'],
+    );
+    let size_dict = HashMap::from([('i', 2), ('j', 3), ('k', 4), ('l', 5)]);
+
+    let nested = optimize_code(&code, &size_dict, &ExhaustiveSearch::default()).unwrap();
+
+    assert!(nested.is_binary());
+    assert_eq!(nested.output_labels(&code.ixs), code.iy);
+}
+
+#[test]
+fn exhaustive_trait_returns_none_for_unsupported_scope() {
+    let code = EinCode::new(vec![vec![0, 0, 1], vec![1, 2], vec![2, 3]], vec![3]);
+    let size_dict = sizes(&[(0, 2), (1, 3), (2, 5), (3, 7)]);
+
+    assert!(optimize_code(&code, &size_dict, &ExhaustiveSearch::default()).is_none());
+}

--- a/omeco/src/lib.rs
+++ b/omeco/src/lib.rs
@@ -62,10 +62,12 @@
 //! | Optimizer | Description |
 //! |-----------|-------------|
 //! | [`GreedyMethod`] | Fast O(n² log n) greedy heuristic |
+//! | [`ExhaustiveSearch`] | Exact dynamic programming for small networks |
 //! | [`TreeSA`] | Simulated annealing for higher-quality solutions |
 //!
-//! Use [`GreedyMethod`] when you need speed; use [`TreeSA`] when contraction
-//! cost dominates and you can afford extra search time.
+//! Use [`GreedyMethod`] when you need speed, [`ExhaustiveSearch`] when the
+//! network is small enough for exact optimization, and [`TreeSA`] when
+//! contraction cost dominates and you can afford extra search time.
 //!
 //! ### Feature 2: Slicing
 //!
@@ -127,6 +129,7 @@
 
 pub mod complexity;
 pub mod eincode;
+pub mod exhaustive;
 pub mod expr_tree;
 pub mod greedy;
 pub mod incidence_list;
@@ -141,12 +144,16 @@ pub mod utils;
 #[cfg(test)]
 pub mod test_utils;
 
+#[cfg(test)]
+mod exhaustive_tests;
+
 // Re-export main types
 pub use complexity::{
     eincode_complexity, flop, nested_complexity, nested_flop, peak_memory, sliced_complexity,
     ContractionComplexity,
 };
 pub use eincode::{log2_size_dict, uniform_size_dict, EinCode, NestedEinsum, SlicedEinsum};
+pub use exhaustive::{optimize_exhaustive, ExhaustiveSearch, ExhaustiveSearchError};
 pub use greedy::{optimize_greedy, ContractionTree, GreedyMethod, GreedyResult};
 pub use label::Label;
 pub use score::ScoreFunction;
@@ -182,6 +189,16 @@ impl CodeOptimizer for TreeSA {
         size_dict: &HashMap<L, usize>,
     ) -> Option<NestedEinsum<L>> {
         optimize_treesa(code, size_dict, self)
+    }
+}
+
+impl CodeOptimizer for ExhaustiveSearch {
+    fn optimize<L: Label>(
+        &self,
+        code: &EinCode<L>,
+        size_dict: &HashMap<L, usize>,
+    ) -> Option<NestedEinsum<L>> {
+        optimize_exhaustive(code, size_dict, self).ok()
     }
 }
 


### PR DESCRIPTION
## Summary
- Add a Rust ExhaustiveSearch optimizer with exact DP over connected components and scope errors for unsupported unary trace/sum cases.
- Expose ExhaustiveSearch and optimize_exhaustive through the Python binding.
- Port the Julia edge-case coverage and document the new optimizer.

## Test Plan
- make check-all
- make python-test