### PR TITLE
Fix #16: expose SlicedEinsum optimized tree

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ print(f"Sliced space: 2^{sliced_comp.sc:.2f}")
 
 # Use with PyTorch (see examples/pytorch_tensor_network_example.py)
 tree_dict = tree.to_dict()  # Convert to dict for traversal
+sliced_tree = sliced.tree()  # Optimized tree after slicing
+sliced_tree_dict = sliced.to_dict()  # Dict for the optimized sliced tree
 ```
 
 ## Rust Quick Start

--- a/docs/src/api-reference.md
+++ b/docs/src/api-reference.md
@@ -51,7 +51,7 @@ def slice_code(
     ixs: List[List[int]],
     sizes: Dict[int, int],
     slicer: Optional[TreeSASlicer] = None
-) -> SlicedCode
+) -> SlicedEinsum
 ```
 
 Apply slicing to reduce memory usage.
@@ -62,7 +62,7 @@ Apply slicing to reduce memory usage.
 - `sizes`: Dimension sizes
 - `slicer`: Slicer instance (optional, defaults to `TreeSASlicer()`)
 
-**Returns**: `SlicedCode` with slicing applied
+**Returns**: `SlicedEinsum` with slicing applied and an optimized contraction tree for each slice
 
 **Example**:
 ```python
@@ -74,6 +74,8 @@ slicer = TreeSASlicer.fast(
     score=ScoreFunction(sc_target=28.0)
 )
 sliced = slice_code(tree, ixs, sizes, slicer)
+sliced_tree = sliced.tree()
+sliced_tree_dict = sliced.to_dict()
 ```
 
 ### Complexity Functions
@@ -330,19 +332,24 @@ print(tree)
 tree_dict = tree.to_dict()
 ```
 
-#### `SlicedCode`
+#### `SlicedEinsum`
 
 Represents a contraction with slicing applied.
 
 **Methods**:
 ```python
-sliced.slicing() -> List[int]   # Get sliced indices
+sliced.slicing() -> List[int]     # Get sliced indices
+sliced.num_slices() -> int        # Number of sliced indices
+sliced.tree() -> NestedEinsum     # Optimized tree for each slice
+sliced.to_dict() -> dict          # Optimized tree as a dict
 ```
 
 **Example**:
 ```python
 sliced = slice_code(tree, ixs, sizes, slicer)
 print(f"Sliced indices: {sliced.slicing()}")
+sliced_tree = sliced.tree()
+tree_dict = sliced.to_dict()
 # Output: [1, 3]
 ```
 

--- a/omeco-python/README.md
+++ b/omeco-python/README.md
@@ -125,6 +125,10 @@ sliced = slice_code(tree, ixs, sizes, slicer)
 c_sliced = sliced_complexity(sliced, ixs, sizes)
 print(f"Sliced:   tc=2^{c_sliced.tc:.2f}, sc=2^{c_sliced.sc:.2f}")
 print(f"Indices to loop over: {sliced.slicing()}")
+print(f"Optimized sliced tree: {sliced.tree()}")
+
+# Convert the optimized sliced tree to dict for traversal/execution
+sliced_tree_dict = sliced.to_dict()
 
 # With fixed slices (indices that must be sliced)
 slicer = TreeSASlicer(fixed_slices=[1, 2], score=ScoreFunction(sc_target=10.0))

--- a/omeco-python/python/omeco/__init__.py
+++ b/omeco-python/python/omeco/__init__.py
@@ -42,6 +42,8 @@ Slicing to reduce memory:
     >>> score = ScoreFunction(sc_target=10.0)
     >>> sliced = slice_code(tree, ixs, sizes, TreeSASlicer.fast(score=score))
     >>> print(f"Sliced indices: {sliced.slicing()}")
+    >>> sliced_tree = sliced.tree()
+    >>> sliced_tree_dict = sliced.to_dict()
     >>>
     >>> # With fixed slices (indices that must be sliced)
     >>> slicer = TreeSASlicer(fixed_slices=[1, 2], score=ScoreFunction(sc_target=10.0))

--- a/omeco-python/src/lib.rs
+++ b/omeco-python/src/lib.rs
@@ -226,6 +226,20 @@ impl PySlicedEinsum {
         self.inner.num_slices()
     }
 
+    /// Get the optimized contraction tree executed for each slice.
+    fn tree(&self) -> PyNestedEinsum {
+        PyNestedEinsum {
+            inner: self.inner.eins.clone(),
+        }
+    }
+
+    /// Convert the optimized contraction tree to a Python dictionary.
+    ///
+    /// This returns the same structure as `NestedEinsum.to_dict()`.
+    fn to_dict(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
+        nested_to_dict(py, &self.inner.eins)
+    }
+
     fn __repr__(&self) -> String {
         format!("SlicedEinsum(slicing={:?})", self.inner.slicing)
     }

--- a/omeco-python/tests/test_omeco.py
+++ b/omeco-python/tests/test_omeco.py
@@ -80,6 +80,20 @@ def test_sliced_einsum():
     assert complexity.sc > 0
 
 
+def test_sliced_einsum_exposes_tree_and_dict():
+    """Test SlicedEinsum exposes its optimized tree."""
+    ixs = [[0, 1], [1, 2]]
+    out = [0, 2]
+    sizes = {0: 10, 1: 20, 2: 10}
+
+    tree = optimize_code(ixs, out, sizes)
+    sliced = SlicedEinsum([1], tree)
+
+    assert sliced.tree().to_dict() == tree.to_dict()
+    assert sliced.to_dict() == tree.to_dict()
+    assert sliced.tree().leaf_count() == tree.leaf_count()
+
+
 def test_uniform_size_dict():
     """Test uniform size dictionary creation."""
     ixs = [[0, 1], [1, 2]]
@@ -291,6 +305,8 @@ def test_slice_code_basic():
     sliced = slice_code(tree, ixs, sizes, slicer)
     assert sliced is not None
     assert sliced.num_slices() >= 0
+    assert sliced.tree().is_binary()
+    assert sliced.to_dict() == sliced.tree().to_dict()
 
 
 def test_slice_code_reduces_space():


### PR DESCRIPTION
## Summary

Expose the optimized contraction tree stored inside Python `SlicedEinsum` results.

## Approach

- Add `SlicedEinsum.tree()` returning the inner optimized `NestedEinsum`.
- Add `SlicedEinsum.to_dict()` delegating to the same nested dictionary format as `NestedEinsum.to_dict()`.
- Cover both constructor-created `SlicedEinsum` values and `slice_code(...)` outputs in Python tests.
- Update Python-facing docs and examples for the new accessors.

## Verification

- `cd omeco-python && python3 -m pytest -q tests/test_omeco.py::test_sliced_einsum_exposes_tree_and_dict tests/test_omeco.py::test_slice_code_basic`
- `make check-all`
- `make python-test`

Closes #16