### PR TITLE
Fix GreedyMethod quadratic scaling (hang at 30k+ tensors)

### DIFF
--- a/omeco/src/greedy.rs
+++ b/omeco/src/greedy.rs
@@ -9,7 +9,7 @@ use crate::Label;
 use priority_queue::PriorityQueue;
 use rand::prelude::*;
 use std::cmp::Ordering;
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeSet, HashMap, HashSet};
 
 /// A binary contraction tree built during greedy optimization.
 #[derive(Debug, Clone)]
@@ -203,19 +203,39 @@ pub fn tree_greedy<E: Label>(
         .collect();
 
     // Initialize priority queue with ONLY neighbor pairs (Julia: evaluate_costs)
-    // This matches Julia's behavior: only consider connected tensors initially
-    let mut pq = PriorityQueue::new();
-    let mut cost_graph: HashSet<(usize, usize)> = HashSet::new();
-    let vertices: Vec<usize> = il.vertices().cloned().collect();
+    // This matches Julia's behavior: only consider connected tensors initially.
+    //
+    // `cost_adj` is an adjacency index of the *cost graph* (Julia's `cost_graph`
+    // `SimpleGraph`): `cost_adj[v]` holds every `u` such that the candidate pair
+    // `(min(u,v), max(u,v))` is currently enqueued. It lets us look up and drop
+    // the pairs incident to a contracted vertex in O(deg) time instead of
+    // scanning the entire candidate set on every contraction (the previous
+    // O(V) rescan made the whole algorithm O(V^2)).
+    //
+    // Vertices and neighbor lists are visited in sorted order so that the queue
+    // is built and mutated in a deterministic sequence. Julia's `IncidenceList`
+    // iterates its `Dict` in a stable order, whereas Rust's randomly-seeded
+    // `HashMap` did not, which made the previous port's greedy output vary
+    // run-to-run on ties. Sorting restores deterministic, Julia-aligned behavior.
+    let mut pq: PriorityQueue<(usize, usize), Cost> = PriorityQueue::new();
+    let mut cost_adj: HashMap<usize, HashSet<usize>> = HashMap::new();
+    let mut vertices: Vec<usize> = il.vertices().cloned().collect();
+    vertices.sort_unstable();
+
+    // Live vertices, kept ordered so the outer-product fallback and final
+    // extraction are deterministic and cheap.
+    let mut live: BTreeSet<usize> = vertices.iter().copied().collect();
 
     for &vi in &vertices {
-        for vj in il.neighbors(&vi) {
+        let mut nbrs = il.neighbors(&vi);
+        nbrs.sort_unstable();
+        for vj in nbrs {
             if vj > vi {
-                let pair = (vi, vj);
                 let dims = ContractionDims::compute(&il, log2_sizes, &vi, &vj);
                 let loss = greedy_loss(&dims, alpha);
-                pq.push(pair, Cost(loss));
-                cost_graph.insert(pair);
+                pq.push((vi, vj), Cost(loss));
+                cost_adj.entry(vi).or_default().insert(vj);
+                cost_adj.entry(vj).or_default().insert(vi);
             }
         }
     }
@@ -225,16 +245,17 @@ pub fn tree_greedy<E: Label>(
 
     // Main greedy loop
     while il.nv() > 1 {
-        // Julia: if cost_values is empty, fall back to arbitrary outer product
+        // Julia: if cost_values is empty, fall back to arbitrary outer product.
+        // We pick the two smallest live vertices for a deterministic choice.
         let (vi, vj) = if pq.is_empty() {
-            let vpool: Vec<usize> = il.vertices().cloned().collect();
-            if vpool.len() < 2 {
-                break;
+            let mut it = live.iter();
+            match (it.next(), it.next()) {
+                (Some(&a), Some(&b)) => (a, b),
+                _ => break,
             }
-            (vpool[0].min(vpool[1]), vpool[0].max(vpool[1]))
         } else {
             // Select pair to contract using temperature sampling
-            let (pair, _) = select_pair(&mut pq, temperature, &mut rng, &mut cost_graph)?;
+            let (pair, _) = select_pair(&mut pq, temperature, &mut rng, &mut cost_adj)?;
             pair
         };
 
@@ -270,34 +291,66 @@ pub fn tree_greedy<E: Label>(
         il.delete_vertex(&vi);
         il.delete_vertex(&vj);
 
+        // Update the live-vertex set.
+        live.remove(&vi);
+        live.remove(&vj);
+        live.insert(new_v);
+
         // Store the new tree
         trees.insert(new_v, new_tree);
 
-        // Julia: update_costs! - only update for neighbors of the new vertex
-        for other_v in il.neighbors(&new_v) {
+        // Julia: update_costs! - only update for neighbors of the new vertex.
+        // `new_v` is a fresh id, so every incident pair is new; the branch
+        // mirrors Julia's `has_edge` check and stays correct if that changes.
+        let mut nbrs = il.neighbors(&new_v);
+        nbrs.sort_unstable();
+        for other_v in nbrs {
             let pair_key = (new_v.min(other_v), new_v.max(other_v));
             let new_dims = ContractionDims::compute(&il, log2_sizes, &new_v, &other_v);
             let loss = greedy_loss(&new_dims, alpha);
 
-            if cost_graph.contains(&pair_key) {
+            let already = cost_adj.get(&new_v).is_some_and(|s| s.contains(&other_v));
+            if already {
                 // Update existing entry
                 pq.change_priority(&pair_key, Cost(loss));
             } else {
                 // Add new entry
                 pq.push(pair_key, Cost(loss));
-                cost_graph.insert(pair_key);
+                cost_adj.entry(new_v).or_default().insert(other_v);
+                cost_adj.entry(other_v).or_default().insert(new_v);
             }
         }
 
-        // Julia: remove edges to deleted vertex vj from cost_graph
-        let pairs_to_remove: Vec<_> = cost_graph
-            .iter()
-            .filter(|(a, b)| *a == vj || *b == vj || *a == vi || *b == vi)
-            .cloned()
-            .collect();
-        for pair in pairs_to_remove {
-            pq.remove(&pair);
-            cost_graph.remove(&pair);
+        // Julia: drop every candidate pair incident to the two contracted
+        // vertices. Using the adjacency index we gather only the O(deg) pairs
+        // that actually reference `vi`/`vj` instead of scanning all candidates.
+        //
+        // The pairs are removed in ascending `(lo, hi)` order. `pq.remove`
+        // rearranges the heap, so the removal order affects how equal-cost
+        // pairs are later broken; iterating incident pairs in the same sorted
+        // order that a full candidate scan would yields identical selections.
+        let mut to_remove: Vec<(usize, usize)> = Vec::new();
+        for &dead in &[vi, vj] {
+            if let Some(partners) = cost_adj.get(&dead) {
+                for &p in partners {
+                    to_remove.push((dead.min(p), dead.max(p)));
+                }
+            }
+        }
+        to_remove.sort_unstable();
+        to_remove.dedup();
+        for pair_key in &to_remove {
+            pq.remove(pair_key);
+        }
+        // Detach `vi`/`vj` from the adjacency index.
+        for &dead in &[vi, vj] {
+            if let Some(partners) = cost_adj.remove(&dead) {
+                for p in partners {
+                    if let Some(s) = cost_adj.get_mut(&p) {
+                        s.remove(&dead);
+                    }
+                }
+            }
         }
     }
 
@@ -318,20 +371,36 @@ pub fn tree_greedy<E: Label>(
     })
 }
 
+/// Remove a candidate pair from the cost-graph adjacency index.
+fn cost_adj_remove(cost_adj: &mut HashMap<usize, HashSet<usize>>, pair: (usize, usize)) {
+    if let Some(s) = cost_adj.get_mut(&pair.0) {
+        s.remove(&pair.1);
+    }
+    if let Some(s) = cost_adj.get_mut(&pair.1) {
+        s.remove(&pair.0);
+    }
+}
+
+/// Insert a candidate pair into the cost-graph adjacency index.
+fn cost_adj_insert(cost_adj: &mut HashMap<usize, HashSet<usize>>, pair: (usize, usize)) {
+    cost_adj.entry(pair.0).or_default().insert(pair.1);
+    cost_adj.entry(pair.1).or_default().insert(pair.0);
+}
+
 /// Select the next pair to contract from the priority queue.
-/// Also updates the cost_graph to track which pairs are in the queue.
+/// Also updates the cost-graph adjacency index to track which pairs are queued.
 fn select_pair<R: Rng>(
     pq: &mut PriorityQueue<(usize, usize), Cost>,
     temperature: f64,
     rng: &mut R,
-    cost_graph: &mut HashSet<(usize, usize)>,
+    cost_adj: &mut HashMap<usize, HashSet<usize>>,
 ) -> Option<((usize, usize), Cost)> {
     if pq.is_empty() {
         return None;
     }
 
     let (pair1, cost1) = pq.pop()?;
-    cost_graph.remove(&pair1);
+    cost_adj_remove(cost_adj, pair1);
 
     if temperature <= 0.0 || pq.is_empty() {
         return Some((pair1, cost1));
@@ -339,7 +408,7 @@ fn select_pair<R: Rng>(
 
     // Boltzmann sampling: consider the second-best option
     let (pair2, cost2) = pq.pop()?;
-    cost_graph.remove(&pair2);
+    cost_adj_remove(cost_adj, pair2);
 
     // Probability of accepting the worse option
     let delta = cost2.0 - cost1.0;
@@ -348,12 +417,12 @@ fn select_pair<R: Rng>(
     if rng.random::<f64>() < prob {
         // Accept the second option, push first back
         pq.push(pair1, cost1);
-        cost_graph.insert(pair1);
+        cost_adj_insert(cost_adj, pair1);
         Some((pair2, cost2))
     } else {
         // Keep the first option, push second back
         pq.push(pair2, cost2);
-        cost_graph.insert(pair2);
+        cost_adj_insert(cost_adj, pair2);
         Some((pair1, cost1))
     }
 }


### PR DESCRIPTION
## Problem

`GreedyMethod` (`omeco/src/greedy.rs`) scaled ~O(V²) and effectively hung above ~30k tensors, even on instances whose greedy result itself is unremarkable. Since TreeSA seeds itself with greedy, this blocked the whole library at scale.

Measured on master (`GreedyMethod::default()`):
- `research/benchmark/uai_relational/uai_relational_4.json` (30,400 tensors): **~84 s**
- `research/benchmark/uai_relational/uai_relational_5.json` (70,000 tensors): **did not complete**

## Root cause

After every contraction, `tree_greedy` rescanned the **entire** candidate-pair set to drop the pairs incident to the two contracted vertices:

```rust
let pairs_to_remove: Vec<_> = cost_graph
    .iter()
    .filter(|(a, b)| *a == vj || *b == vj || *a == vi || *b == vi)
    .cloned()
    .collect();
```

That scan is O(|candidates|) = O(V) per contraction, so the whole loop is **O(V²)**. `uai_relational_4` is a single connected component, so the outer-product fallback barely triggers — the scan is the sole bottleneck.

## Fix (performance only — selection sequence preserved)

- Maintain `cost_adj: HashMap<usize, HashSet<usize>>`, an adjacency index of the cost graph (the Rust analogue of Julia's `cost_graph::SimpleGraph`). Stale-pair removal now touches only the **O(deg)** pairs incident to the contracted vertices. The loop becomes O(V · deg · log V).
- Remove incident pairs in the same ascending `(lo, hi)` order a full scan would use. `pq.remove` rearranges the heap, so removal order influences how equal-cost pairs break in later pops; matching the scan order keeps selections identical.
- Iterate vertices / neighbor lists in sorted order and pick the two smallest live vertices in the outer-product fallback. Julia iterates its `IncidenceList` `Dict` in a stable order; Rust's randomly-seeded `HashMap` did not, so the prior port's greedy output — and even its tc/sc — **varied run-to-run on ties**. Sorting restores deterministic, Julia-aligned behavior.

## Bit-identical verification

master's greedy is nondeterministic run-to-run (the random hash seed permutes initial PQ insertion order and thus tie-breaking), so it cannot be diffed against itself. To get a meaningful identity check I built a **"determinized master"** reference: master's exact O(V)-scan algorithm plus *only* the sorted-iteration changes. Comparing `writejson` output byte-for-byte against this optimized version:

**All 14 checkable instances IDENTICAL** — `benchmarks/graphs/*.json` (chain_10, chain_20, grid_4x4/5x5/6x6, petersen, reg3_50/100/220/250) plus `uai_DBN_13`, `uai_linkage_15`, `uai_CSP_11`, `uai_relational_3`. (The very large relational instances can't be diffed because master is too slow to produce a baseline — that's the bug.)

This proves the adjacency-index change does not alter the pair-selection sequence. Additionally, the optimized version is deterministic run-to-run, and its tc lands within master's observed distribution (e.g. reg3_250: 66.3 in [65.2, 73.0]; uai_relational_3: 17.05 = master's min).

## Before / after timings (`GreedyMethod::default()`)

| Instance | Tensors | master | this PR |
|---|---:|---:|---:|
| uai_relational_4 | 30,400 | ~84 s | ~9 s |
| uai_relational_5 | 70,000 | did not complete | 3.7 s |

70k now runs *faster* than 30k, confirming the O(V²) term is gone — relational_4's residual cost is inherent to its high-degree intermediate tensors (sc=200), which master also paid but was dwarfed by the scan.

## Checks

- `make check-all` (fmt-check + clippy `-D warnings` + test): **All checks passed** (441 unit + 20 doctests). No existing tests modified.

Julia reference consulted: `~/.julia/dev/OMEinsumContractionOrders/src/greedy.jl` (`evaluate_costs` / `update_costs!` / `find_best_cost!`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)