### PR TITLE
Review hardening: scalar merges, O(log n) FM selection, cleanups

### DIFF
--- a/omeco/src/lib.rs
+++ b/omeco/src/lib.rs
@@ -101,6 +101,15 @@
 //! println!("sliced space: 2^{:.2}", metrics.sc);
 //! ```
 //!
+//! ## Limitations
+//!
+//! Contraction trees are processed recursively throughout the crate (tree
+//! construction, conversion, complexity evaluation, and `Drop`). Tree depth is
+//! bounded by the number of tensors, so pathologically deep trees — e.g. a
+//! matrix chain of hundreds of thousands of tensors, whose optimal tree is a
+//! caterpillar — can exhaust the thread stack. Networks in the tested range
+//! (up to tens of thousands of tensors) are fine.
+//!
 //! ## Algorithm Details
 //!
 //! ### GreedyMethod

--- a/omeco/src/preprocess.rs
+++ b/omeco/src/preprocess.rs
@@ -233,6 +233,12 @@ pub fn simplify<L: Label + Ord>(code: &EinCode<L>, size_dict: &HashMap<L, usize>
                 }
             }
         }
+        // A scalar shares no labels, so the scan above never finds it a
+        // partner; merging it into any live tensor is always rank- and
+        // size-non-increasing. Pick the smallest live id for determinism.
+        if chosen.is_none() && lab_list.is_empty() {
+            chosen = (0..n).find(|&u| u != t && alive[u]);
+        }
         let Some(u) = chosen else { continue };
 
         // Merge u into t. Build the internal binary subtree node.
@@ -412,6 +418,39 @@ mod tests {
                 assert_recursive_interfaces(child, original_ixs);
             }
         }
+    }
+
+    #[test]
+    fn test_simplify_merges_scalars_into_neighbours() {
+        // t1 is a scalar (rank 0). Merging it into any tensor is always
+        // rank- and size-non-increasing, so the whole network (matrix chain
+        // plus scalar) must collapse to a single super-tensor whose subtree
+        // still contains every original leaf.
+        let code = EinCode::new(vec![vec!['i', 'j'], vec![], vec!['j', 'k']], vec!['i', 'k']);
+        let sizes = uniform_sizes(&code, 2);
+        let simp = simplify(&code, &sizes);
+        assert_eq!(simp.report.n_reduced, 1, "scalar must not block collapse");
+        let inner = optimize_code(&simp.code, &sizes, &GreedyMethod::default()).unwrap();
+        let tree = splice(&inner, &simp.subtrees);
+        assert_eq!(
+            tree.leaf_count(),
+            3,
+            "the scalar leaf must survive splicing"
+        );
+        assert_recursive_interfaces(&tree, &code.ixs);
+    }
+
+    #[test]
+    fn test_simplify_all_scalar_network_collapses() {
+        // Nothing but scalars: they must all fold into one super-tensor.
+        let code = EinCode::new(vec![vec![], vec![], vec![]], Vec::<char>::new());
+        let sizes: HashMap<char, usize> = HashMap::new();
+        let simp = simplify(&code, &sizes);
+        assert_eq!(simp.report.n_reduced, 1);
+        let inner = optimize_code(&simp.code, &sizes, &GreedyMethod::default()).unwrap();
+        let tree = splice(&inner, &simp.subtrees);
+        assert_eq!(tree.leaf_count(), 3);
+        assert_recursive_interfaces(&tree, &code.ixs);
     }
 
     #[test]

--- a/omeco/src/treesa.rs
+++ b/omeco/src/treesa.rs
@@ -538,7 +538,6 @@ fn expr_tree_to_nested<L: Label>(
     original_ixs: &[Vec<L>],
     inverse_map: &[L],
     openedges: &[L],
-    _level: usize,
 ) -> NestedEinsum<L> {
     // Global occurrence count of every label across all original tensors.
     let mut global_count: HashMap<L, usize> = HashMap::new();
@@ -595,10 +594,10 @@ fn expr_tree_to_nested_counted<L: Label>(
             let inverse = inverse_map;
             let globals = global_count;
             let next_level = level + 1;
-            let convert = expr_tree_to_nested_counted::<L>;
-            let (left_nested, left_within, left_out) =
-                convert(left, ixs, inverse, open_set, globals, openedges, next_level);
-            let (right_nested, right_within, right_out) = convert(
+            let (left_nested, left_within, left_out) = expr_tree_to_nested_counted(
+                left, ixs, inverse, open_set, globals, openedges, next_level,
+            );
+            let (right_nested, right_within, right_out) = expr_tree_to_nested_counted(
                 right, ixs, inverse, open_set, globals, openedges, next_level,
             );
 
@@ -722,7 +721,7 @@ pub fn optimize_treesa<L: Label>(
             // SA-internal `tree_complexity` does not count dangling-label
             // reductions (matching Julia's `tcscrw`), so ranking trials by it
             // can select a tree that is worse than another trial's.
-            let nested = expr_tree_to_nested(&optimized, &code.ixs, &labels, &code.iy, 0);
+            let nested = expr_tree_to_nested(&optimized, &code.ixs, &labels, &code.iy);
             let cc = crate::contraction_complexity(&nested, size_dict, &code.ixs);
             let score = config.score.evaluate(cc.tc, cc.sc, cc.rwc);
 
@@ -828,7 +827,7 @@ pub fn warm_exprtree_to_nested<L: Label>(
     code: &EinCode<L>,
     labels: &[L],
 ) -> NestedEinsum<L> {
-    expr_tree_to_nested(tree, &code.ixs, labels, &code.iy, 0)
+    expr_tree_to_nested(tree, &code.ixs, labels, &code.iy)
 }
 
 #[cfg(test)]
@@ -915,7 +914,7 @@ mod tests {
                         &mut trng,
                         nedge,
                     );
-                    let nested = expr_tree_to_nested(&optimized, &code.ixs, &labels, &code.iy, 0);
+                    let nested = expr_tree_to_nested(&optimized, &code.ixs, &labels, &code.iy);
                     let tcc = contraction_complexity(&nested, &size_dict, &code.ixs);
                     config.score.evaluate(tcc.tc, tcc.sc, tcc.rwc)
                 })
@@ -1382,7 +1381,7 @@ mod tests {
         let inverse_map = vec!['i', 'j', 'k'];
         let openedges = vec!['i', 'k'];
 
-        let nested = expr_tree_to_nested(&tree, &original_ixs, &inverse_map, &openedges, 0);
+        let nested = expr_tree_to_nested(&tree, &original_ixs, &inverse_map, &openedges);
 
         assert!(nested.is_binary());
         assert_eq!(nested.leaf_count(), 2);
@@ -1403,7 +1402,7 @@ mod tests {
         let inverse_map = vec!['i', 'j', 'k', 'l'];
         let openedges = vec!['i', 'l'];
 
-        let nested = expr_tree_to_nested(&tree, &original_ixs, &inverse_map, &openedges, 0);
+        let nested = expr_tree_to_nested(&tree, &original_ixs, &inverse_map, &openedges);
 
         assert!(nested.is_binary());
         assert_eq!(nested.leaf_count(), 3);
@@ -1476,7 +1475,7 @@ mod tests {
         );
         let root = ExprTree::node(a, b, vec![1, 2, 3, 4]);
 
-        let nested = expr_tree_to_nested(&root, &original_ixs, &inverse_map, &openedges, 0);
+        let nested = expr_tree_to_nested(&root, &original_ixs, &inverse_map, &openedges);
 
         // Each intermediate node must keep label 0 (it occurs outside its subtree).
         if let NestedEinsum::Node { args, .. } = &nested {

--- a/omeco/src/waist_surgery.rs
+++ b/omeco/src/waist_surgery.rs
@@ -57,7 +57,8 @@
 //! assert_eq!(report.n_original, 4);
 //! ```
 
-use std::collections::{HashMap, HashSet, VecDeque};
+use std::cmp::Reverse;
+use std::collections::{BTreeSet, HashMap, HashSet, VecDeque};
 use std::time::{Duration, Instant};
 
 use rand::rngs::SmallRng;
@@ -84,6 +85,11 @@ const FM_SLACK: f64 = 0.18;
 
 /// Maximum FM passes per cut-improvement call.
 const FM_MAX_PASSES: usize = 6;
+
+/// Labels with more member tensors than this cap skip incremental gain
+/// recomputation after a move (their neighbours keep a stale gain until the
+/// next pass); the final acceptance rescore in the caller stays exact.
+const FM_GAIN_UPDATE_DEG_CAP: usize = 256;
 
 /// Number of coarse super-nodes the top span selects (`S_top = ceil(m/30)`).
 const TARGET_TOP: usize = 30;
@@ -227,6 +233,19 @@ impl Hyper {
 // Fiduccia–Mattheyses bipartition refinement on the tensor hypergraph.
 // =============================================================================
 
+/// Map a gain to a `u64` that orders like the float. `+ 0.0` normalizes `-0.0`
+/// to `+0.0` so numerically equal gains get equal keys; gains are finite sums
+/// of `log2` dimensions, never NaN.
+#[inline]
+fn gain_key(g: f64) -> u64 {
+    let bits = (g + 0.0).to_bits();
+    if bits >> 63 == 0 {
+        bits | (1 << 63)
+    } else {
+        !bits
+    }
+}
+
 /// Improve a bipartition by bounded FM passes. `part[t] == true` means side A.
 /// Balance is constrained so `|A|` stays within `[lo, hi]`. Returns the improved
 /// partition and its straddle-cut cost.
@@ -278,6 +297,19 @@ fn fm_refine(
         }
         let mut gain: Vec<f64> = (0..n).map(|t| gain_of(t, &part, &cnt_a)).collect();
         let mut locked = vec![false; n];
+        // Unlocked move candidates by current side. The maximum entry is
+        // (max gain, then smallest vertex) — the same move a linear scan over
+        // `gain` picks — at O(log n) per query/update instead of O(n) per step.
+        let mut side_a: BTreeSet<(u64, Reverse<usize>)> = BTreeSet::new();
+        let mut side_b: BTreeSet<(u64, Reverse<usize>)> = BTreeSet::new();
+        for t in 0..n {
+            let entry = (gain_key(gain[t]), Reverse(t));
+            if part[t] {
+                side_a.insert(entry);
+            } else {
+                side_b.insert(entry);
+            }
+        }
         let mut cur_cost = hyper.cut_cost(&part);
         let mut best_seen_cost = cur_cost;
         let mut best_seen_part = part.clone();
@@ -288,22 +320,27 @@ fn fm_refine(
                 break;
             }
             // Pick max-gain unlocked feasible move.
-            let mut bv: Option<usize> = None;
-            let mut bg = f64::NEG_INFINITY;
-            for t in 0..n {
-                if locked[t] {
-                    continue;
-                }
-                let feasible = if part[t] { size_a > lo } else { size_a < hi };
-                if !feasible {
-                    continue;
-                }
-                if gain[t] > bg {
-                    bg = gain[t];
-                    bv = Some(t);
-                }
+            let cand_a = if size_a > lo {
+                side_a.last().copied()
+            } else {
+                None
+            };
+            let cand_b = if size_a < hi {
+                side_b.last().copied()
+            } else {
+                None
+            };
+            let best = match (cand_a, cand_b) {
+                (Some(a), Some(b)) => Some(a.max(b)),
+                (a, b) => a.or(b),
+            };
+            let Some((_, Reverse(v))) = best else { break };
+            let ventry = (gain_key(gain[v]), Reverse(v));
+            if part[v] {
+                side_a.remove(&ventry);
+            } else {
+                side_b.remove(&ventry);
             }
-            let Some(v) = bv else { break };
 
             // Apply the move.
             cur_cost -= gain[v];
@@ -324,7 +361,7 @@ fn fm_refine(
             // Recompute gains of all vertices sharing a label with v.
             let mut touched: Vec<usize> = Vec::new();
             for &l in &hyper.tlabels[v] {
-                if hyper.label_tensors[l].len() > 256 {
+                if hyper.label_tensors[l].len() > FM_GAIN_UPDATE_DEG_CAP {
                     continue;
                 }
                 for &u in &hyper.label_tensors[l] {
@@ -334,7 +371,13 @@ fn fm_refine(
             touched.sort_unstable();
             touched.dedup();
             for &u in &touched {
-                gain[u] = gain_of(u, &part, &cnt_a);
+                let new_gain = gain_of(u, &part, &cnt_a);
+                if !locked[u] {
+                    let set = if part[u] { &mut side_a } else { &mut side_b };
+                    set.remove(&(gain_key(gain[u]), Reverse(u)));
+                    set.insert((gain_key(new_gain), Reverse(u)));
+                }
+                gain[u] = new_gain;
             }
 
             if cur_cost < best_seen_cost - 1e-12 {
@@ -1031,6 +1074,241 @@ mod tests {
 
     fn uniform_sizes(code: &EinCode<usize>, d: usize) -> HashMap<usize, usize> {
         code.unique_labels().into_iter().map(|l| (l, d)).collect()
+    }
+
+    /// Reference FM with the original linear-scan move selection (max gain,
+    /// then smallest vertex, feasibility by side). `fm_refine` must match this
+    /// exactly whatever selection data structure it uses internally.
+    fn fm_refine_reference(
+        hyper: &Hyper,
+        mut part: Vec<bool>,
+        lo: usize,
+        hi: usize,
+        start: Instant,
+        budget: Duration,
+    ) -> (Vec<bool>, f64) {
+        let n = hyper.n;
+        let nlab = hyper.log2.len();
+        let mut cnt_a = vec![0u32; nlab];
+        for (t, &p) in part.iter().enumerate() {
+            if p {
+                for &l in &hyper.tlabels[t] {
+                    cnt_a[l] += 1;
+                }
+            }
+        }
+        let mut size_a = part.iter().filter(|&&p| p).count();
+
+        let gain_of = |t: usize, part: &[bool], cnt_a: &[u32]| -> f64 {
+            let mut g = 0.0;
+            for &l in &hyper.tlabels[t] {
+                if hyper.is_out[l] {
+                    continue;
+                }
+                let deg = hyper.label_tensors[l].len() as u32;
+                let (cs, ct) = if part[t] {
+                    (cnt_a[l], deg - cnt_a[l])
+                } else {
+                    (deg - cnt_a[l], cnt_a[l])
+                };
+                let before = (ct >= 1) as i32;
+                let after = (cs >= 2) as i32;
+                g += hyper.log2[l] * (before - after) as f64;
+            }
+            g
+        };
+
+        let mut best_cost = hyper.cut_cost(&part);
+
+        for _pass in 0..FM_MAX_PASSES {
+            if start.elapsed() >= budget {
+                break;
+            }
+            let mut gain: Vec<f64> = (0..n).map(|t| gain_of(t, &part, &cnt_a)).collect();
+            let mut locked = vec![false; n];
+            let mut cur_cost = hyper.cut_cost(&part);
+            let mut best_seen_cost = cur_cost;
+            let mut best_seen_part = part.clone();
+            let mut improved_this_pass = false;
+
+            for _step in 0..n {
+                if start.elapsed() >= budget {
+                    break;
+                }
+                let mut bv: Option<usize> = None;
+                let mut bg = f64::NEG_INFINITY;
+                for t in 0..n {
+                    if locked[t] {
+                        continue;
+                    }
+                    let feasible = if part[t] { size_a > lo } else { size_a < hi };
+                    if !feasible {
+                        continue;
+                    }
+                    if gain[t] > bg {
+                        bg = gain[t];
+                        bv = Some(t);
+                    }
+                }
+                let Some(v) = bv else { break };
+
+                cur_cost -= gain[v];
+                if part[v] {
+                    for &l in &hyper.tlabels[v] {
+                        cnt_a[l] -= 1;
+                    }
+                    size_a -= 1;
+                } else {
+                    for &l in &hyper.tlabels[v] {
+                        cnt_a[l] += 1;
+                    }
+                    size_a += 1;
+                }
+                part[v] = !part[v];
+                locked[v] = true;
+
+                let mut touched: Vec<usize> = Vec::new();
+                for &l in &hyper.tlabels[v] {
+                    if hyper.label_tensors[l].len() > 256 {
+                        continue;
+                    }
+                    for &u in &hyper.label_tensors[l] {
+                        touched.push(u);
+                    }
+                }
+                touched.sort_unstable();
+                touched.dedup();
+                for &u in &touched {
+                    gain[u] = gain_of(u, &part, &cnt_a);
+                }
+
+                if cur_cost < best_seen_cost - 1e-12 {
+                    best_seen_cost = cur_cost;
+                    best_seen_part = part.clone();
+                    improved_this_pass = true;
+                }
+            }
+
+            part = best_seen_part;
+            cnt_a.iter_mut().for_each(|c| *c = 0);
+            size_a = 0;
+            for (t, &p) in part.iter().enumerate() {
+                if p {
+                    size_a += 1;
+                    for &l in &hyper.tlabels[t] {
+                        cnt_a[l] += 1;
+                    }
+                }
+            }
+            best_cost = best_seen_cost;
+            if !improved_this_pass {
+                break;
+            }
+        }
+        (part, best_cost)
+    }
+
+    #[test]
+    #[ignore]
+    fn perf_fm_refine_large() {
+        use rand::Rng;
+        use rand::SeedableRng;
+        let mut rng = rand::rngs::SmallRng::seed_from_u64(7);
+        let n_tensors = 20000usize;
+        let n_labels = 4000usize;
+        let ixs: Vec<Vec<usize>> = (0..n_tensors)
+            .map(|_| {
+                let mut v: Vec<usize> = (0..3).map(|_| rng.random_range(0..n_labels)).collect();
+                v.sort_unstable();
+                v.dedup();
+                v
+            })
+            .collect();
+        let code = EinCode::new(ixs, Vec::new());
+        let label_map: HashMap<usize, usize> = (0..n_labels).map(|l| (l, l)).collect();
+        let log2: Vec<f64> = (0..n_labels).map(|_| 1.0).collect();
+        let hyper = Hyper::build(&code, &label_map, &log2, n_labels);
+        let part: Vec<bool> = (0..n_tensors).map(|t| t % 2 == 0).collect();
+        let lo = n_tensors / 4;
+        let hi = 3 * n_tensors / 4;
+        let budget = Duration::from_secs(3600);
+        let t0 = Instant::now();
+        let (p1, c1) = fm_refine(&hyper, part.clone(), lo, hi, Instant::now(), budget);
+        let new_t = t0.elapsed();
+        let t1 = Instant::now();
+        let (p2, c2) = fm_refine_reference(&hyper, part, lo, hi, Instant::now(), budget);
+        let ref_t = t1.elapsed();
+        assert_eq!(p1, p2);
+        assert!((c1 - c2).abs() < 1e-9);
+        println!("n=20000: new {new_t:?} vs reference {ref_t:?}");
+    }
+
+    #[test]
+    fn test_fm_refine_matches_reference_selection() {
+        use rand::Rng;
+        use rand::SeedableRng;
+
+        for seed in 0..80u64 {
+            let mut rng = rand::rngs::SmallRng::seed_from_u64(seed);
+            // Occasionally exceed the gain-update degree cap with one label
+            // shared by every tensor, to exercise the stale-gain path too.
+            let big = seed % 10 == 0;
+            let n_tensors = if big { 300 } else { rng.random_range(6..=40) };
+            let n_labels = if big { 40 } else { rng.random_range(4..=12) };
+            let mut ixs: Vec<Vec<usize>> = (0..n_tensors)
+                .map(|_| {
+                    let k = rng.random_range(1..=3.min(n_labels));
+                    let mut pool: Vec<usize> = (0..n_labels).collect();
+                    let mut chosen = Vec::with_capacity(k);
+                    for _ in 0..k {
+                        let idx = rng.random_range(0..pool.len());
+                        chosen.push(pool.swap_remove(idx));
+                    }
+                    chosen.sort_unstable();
+                    chosen
+                })
+                .collect();
+            if big {
+                for ix in ixs.iter_mut() {
+                    if !ix.contains(&0) {
+                        ix.insert(0, 0);
+                    }
+                }
+            }
+            let iy: Vec<usize> = (0..n_labels)
+                .filter(|_| rng.random_range(0..4) == 0)
+                .collect();
+            let code = EinCode::new(ixs, iy);
+            let label_map: HashMap<usize, usize> = (0..n_labels).map(|l| (l, l)).collect();
+            let log2: Vec<f64> = (0..n_labels)
+                .map(|_| (rng.random_range(1..=4) as f64).log2())
+                .collect();
+            let hyper = Hyper::build(&code, &label_map, &log2, n_labels);
+
+            let part: Vec<bool> = (0..n_tensors)
+                .map(|_| rng.random_range(0..2) == 0)
+                .collect();
+            let size_a = part.iter().filter(|&&p| p).count();
+            let lo = size_a.saturating_sub(n_tensors / 4).max(1);
+            let hi = (size_a + n_tensors / 4).min(n_tensors - 1);
+            if lo > hi {
+                continue;
+            }
+
+            let start = Instant::now();
+            let budget = Duration::from_secs(3600);
+            let (part_new, cost_new) = fm_refine(&hyper, part.clone(), lo, hi, start, budget);
+            let (part_ref, cost_ref) =
+                fm_refine_reference(&hyper, part.clone(), lo, hi, start, budget);
+            assert_eq!(
+                part_new, part_ref,
+                "seed {seed}: fm_refine diverged from reference selection"
+            );
+            assert!(
+                (cost_new - cost_ref).abs() < 1e-12,
+                "seed {seed}: cost {cost_new} != reference {cost_ref}"
+            );
+        }
     }
 
     /// Build a 2D periodic grid tensor network (each bond a distinct label).


### PR DESCRIPTION
Stacked on #25 (base is `jg/treesa-trial-scoring`; retarget to `master` after #25 merges). Closes the remaining deferred review findings from the #20 review. **Do not merge until approved.**

## Changes

- **`preprocess::simplify` merges scalars.** Rank-0 tensors share no labels, so the label-driven partner scan never found them and they blocked full collapse. They now merge into the smallest-id live tensor (always rank- and size-non-increasing). TDD: red tests first (`test_simplify_merges_scalars_into_neighbours`, `test_simplify_all_scalar_network_collapses`).
- **`fm_refine` selection is O(log n) per move** instead of O(n): one `BTreeSet` per side keyed by gain bits so the maximum entry is exactly the move the old linear scan picked (max gain, then smallest vertex; -0.0 normalized). Semantics are frozen by `test_fm_refine_matches_reference_selection`: an 80-case differential fuzz against a verbatim copy of the old implementation, including >256-degree labels exercising the stale-gain path. Measured 5.5× faster at n=20 000 / 4 000 labels (730 ms vs 4.04 s, `perf_fm_refine_large`, `#[ignore]`d) — this matters for the relational family where reduced networks reach n=10 000.
- **Named the FM degree cap** `FM_GAIN_UPDATE_DEG_CAP` (was a bare `256`).
- **Cleanups:** removed the unused `_level` parameter of `expr_tree_to_nested` and the `convert` fn-pointer indirection.
- **Documented** the crate-wide recursion-depth limitation (deep caterpillar trees) in the crate docs — recursion is pervasive (construction, conversion, complexity, `Drop`), so a spot-fix in the new modules would not change the real limit; a full iterative rewrite is out of scope here.

## Validation

- `make check-all`: formatting, clippy, 500 unit tests + 34 doctests — all pass.
- Julia-alignment benchmark tests unmodified and passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)