### PR TITLE
TreeSA pipeline flags: preprocess default, opt-in surgery; retire Julia alignment

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -3,7 +3,7 @@
 ## Project Overview
 - **OMECO** (One More Einsum Contraction Order) - Rust library for tensor network contraction order optimization
 - Rust core with Python bindings via PyO3
-- Current Version: 0.2.3
+- Current Version: 0.2.7
 
 ## Relationship to Julia OMEinsumContractionOrders
 

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -5,19 +5,15 @@
 - Rust core with Python bindings via PyO3
 - Current Version: 0.2.3
 
-## CRITICAL: Alignment with Julia OMEinsumContractionOrders
+## Relationship to Julia OMEinsumContractionOrders
 
-**This project MUST stay aligned with [OMEinsumContractionOrders.jl](https://github.com/TensorBFS/OMEinsumContractionOrders.jl).**
-
-When making changes:
-1. **Check Julia implementation first** at `~/.julia/dev/OMEinsumContractionOrders/`
-2. **Match algorithm behavior** - TreeSA, GreedyMethod, and complexity calculations must produce equivalent results
-3. **Run comparative benchmarks** to verify alignment
-4. **Key files to compare:**
-   - `treesa.jl` ↔ `omeco/src/treesa.rs`
-   - `greedy.jl` ↔ `omeco/src/greedy.rs`
-   - `simplify.jl` ↔ `omeco/src/simplifier.rs`
-   - `json.jl` ↔ `omeco/src/json.rs`
+omeco originated as a port of
+[OMEinsumContractionOrders.jl](https://github.com/TensorBFS/OMEinsumContractionOrders.jl)
+and keeps **JSON interop** (`writejson`/`readjson`) as a compatibility
+contract. Behavior and defaults are independent: changes are judged on
+omeco's own results and ergonomics, not parity with Julia. The Julia
+implementation at `~/.julia/dev/OMEinsumContractionOrders/` remains a
+useful reference when porting algorithms.
 
 ## Development Setup
 
@@ -97,8 +93,7 @@ make github-release     # 4. Create GitHub release with auto-generated notes
 - Rust: inline `#[test]` modules in source files
 - Python: tests in `omeco-python/tests/`
 - Use `criterion` for benchmarks
-- **Always compare results with Julia implementation**
-- **CRITICAL: Do NOT modify existing tests unless explicitly instructed by the user.** Tests marked "ALIGNED WITH JULIA" are verified against the Julia implementation and must not be changed.
+- Do not weaken existing regression tests to make a change pass; update expectations only with a comment explaining the behavior change.
 
 ## Project Structure
 
@@ -134,7 +129,6 @@ examples/           # Usage examples
 - Coverage >95%
 - Clippy with no warnings
 - Proper formatting
-- **Benchmark tc values must match Julia within tolerance**
 
 ## Benchmarks
 
@@ -164,14 +158,14 @@ Shared graphs in `benchmarks/graphs/`:
 - `reg3_50.json`, `reg3_100.json`, `reg3_250.json` - Random 3-regular graphs
 
 ### Expected Results
-TreeSA tc values should match Julia within stochastic variation:
-- Chain/grid graphs: exact match expected
-- Random graphs: within ~5% due to stochastic optimization
+TreeSA tc values can be compared against Julia with stochastic variation:
+- Chain/grid graphs: typically close match
+- Random graphs: within ~5% of Julia results expected due to stochastic optimization
 
 ## Debugging Performance Issues
 
-If TreeSA produces worse results than Julia:
+When investigating TreeSA results:
 1. Compare default parameters (betas, ntrials, niters)
 2. Check `contraction_output` logic in `expr_tree.rs`
 3. Verify `expr_tree_to_nested` correctly converts tree to NestedEinsum
-4. Run the same graph through both implementations and compare tc/sc
+4. Run the same graph through both implementations and compare tc/sc against Julia for reference

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog
+
+## 0.2.7 — 2026-07-29
+
+**Default behavior change:** `TreeSA` now runs the structural
+simplification front-end by default (`preprocess: true`) — output trees
+may differ from 0.2.6 (same contraction result, typically equal or better
+cost). Restore the old behavior with `preprocess: false`.
+
+- New `TreeSA.surgery_budget` (seconds, default 0.0/off): opt-in
+  waist-surgery post-pass; never worse than the unrefined tree, wall-clock
+  dependent.
+- Python: `TreeSA(preprocess=..., surgery_budget=...)`,
+  `simplify_then_optimize`, `waist_refine`, `SimplifyReport`, `WaistReport`.
+- `Label` now requires `Ord` (all built-in label types already qualify).
+- The Julia behavioral-alignment rule is retired; JSON interop is unchanged.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,12 @@ simplification front-end by default (`preprocess: true`) — output trees
 may differ from 0.2.6 (same contraction result, typically equal or better
 cost). Restore the old behavior with `preprocess: false`.
 
-- New `TreeSA.surgery_budget` (seconds, default 0.0/off): opt-in
-  waist-surgery post-pass; never worse than the unrefined tree, wall-clock
-  dependent.
-- Python: `TreeSA(preprocess=..., surgery_budget=...)`,
+- New `TreeSA.surgery_iters` (default `0`/off): deterministic iteration cap
+  for a waist-surgery post-pass; never worse than the unrefined tree, and
+  fully reproducible across machines for any fixed config. `TreeSA` has no
+  wall-clock knob — the low-level `waist_surgery::refine`/`refine_capped`
+  APIs keep their `Duration` budget for power users.
+- Python: `TreeSA(preprocess=..., surgery_iters=...)`,
   `simplify_then_optimize`, `waist_refine`, `SimplifyReport`, `WaistReport`.
 - `Label` now requires `Ord` (all built-in label types already qualify).
 - The Julia behavioral-alignment rule is retired; JSON interop is unchanged.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -417,7 +417,7 @@ dependencies = [
 
 [[package]]
 name = "omeco"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "criterion",
  "ndarray",
@@ -433,7 +433,7 @@ dependencies = [
 
 [[package]]
 name = "omeco-python"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "omeco",
  "pyo3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["omeco", "omeco-python"]
 resolver = "2"
 
 [workspace.package]
-version = "0.2.6"
+version = "0.2.7"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/GiggleLiu/omeco"

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Add to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-omeco = "0.1"
+omeco = "0.2"
 ```
 
 ## Python Quick Start

--- a/README.md
+++ b/README.md
@@ -50,8 +50,8 @@ omeco = "0.2"
 ## Python Quick Start
 
 `TreeSA()` runs the full default pipeline (simplify, anneal, splice) with no
-tuning required. Give it a `surgery_budget` (seconds) to spend extra
-wall-clock time for a result that's never worse — see the
+tuning required. Give it a `surgery_iters` cap to run extra, deterministic
+surgery iterations for a result that's never worse — see the
 [Default Pipeline](https://GiggleLiu.github.io/omeco/algorithms/default-pipeline.html)
 page for what each stage does and when surgery helps:
 
@@ -63,7 +63,7 @@ out = [0, 3]
 sizes = {0: 100, 1: 200, 2: 50, 3: 100}
 
 tree = optimize_code(ixs, out, sizes, TreeSA())        # full default pipeline
-better = optimize_code(ixs, out, sizes, TreeSA(surgery_budget=30.0))  # spend time, get a better tree
+better = optimize_code(ixs, out, sizes, TreeSA(surgery_iters=20))  # deterministic knob, get a better tree
 print(contraction_complexity(tree, ixs, sizes))
 ```
 
@@ -102,8 +102,8 @@ sliced_tree_dict = sliced.to_dict()  # Dict for the optimized sliced tree
 ## Rust Quick Start
 
 `TreeSA::default()` runs the full default pipeline (simplify, anneal,
-splice) with no tuning required. Chain `.with_surgery_budget(30.0)` to spend
-extra wall-clock time (seconds) for a result that's never worse — see the
+splice) with no tuning required. Chain `.with_surgery_iters(20)` to run extra,
+deterministic surgery iterations for a result that's never worse — see the
 [Default Pipeline](https://GiggleLiu.github.io/omeco/algorithms/default-pipeline.html)
 page for what each stage does and when surgery helps:
 
@@ -123,8 +123,8 @@ sizes.insert('l', 100);
 
 // full default pipeline
 let tree = optimize_code(&code, &sizes, &TreeSA::default()).unwrap();
-// spend time, get a better tree
-let better = optimize_code(&code, &sizes, &TreeSA::default().with_surgery_budget(30.0)).unwrap();
+// deterministic knob, get a better tree
+let better = optimize_code(&code, &sizes, &TreeSA::default().with_surgery_iters(20)).unwrap();
 let complexity = contraction_complexity(&tree, &sizes, &code.ixs);
 println!("Time: 2^{:.2}, Space: 2^{:.2}", complexity.tc, complexity.sc);
 ```

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 Tensor network contraction order optimization in Rust.
 
-Ported from [OMEinsumContractionOrders.jl](https://github.com/TensorBFS/OMEinsumContractionOrders.jl).
+Originated as a port of [OMEinsumContractionOrders.jl](https://github.com/TensorBFS/OMEinsumContractionOrders.jl).
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,27 @@ omeco = "0.1"
 
 ## Python Quick Start
 
+`TreeSA()` runs the full default pipeline (simplify, anneal, splice) with no
+tuning required. Give it a `surgery_budget` (seconds) to spend extra
+wall-clock time for a result that's never worse — see the
+[Default Pipeline](https://GiggleLiu.github.io/omeco/algorithms/default-pipeline.html)
+page for what each stage does and when surgery helps:
+
+```python
+from omeco import optimize_code, contraction_complexity, TreeSA
+
+ixs = [[0, 1], [1, 2], [2, 3]]
+out = [0, 3]
+sizes = {0: 100, 1: 200, 2: 50, 3: 100}
+
+tree = optimize_code(ixs, out, sizes, TreeSA())        # full default pipeline
+better = optimize_code(ixs, out, sizes, TreeSA(surgery_budget=30.0))  # spend time, get a better tree
+print(contraction_complexity(tree, ixs, sizes))
+```
+
+`GreedyMethod` is faster and lower-quality; `TreeSASlicer` reduces peak memory
+by slicing:
+
 ```python
 from omeco import (
     optimize_code, slice_code, contraction_complexity, sliced_complexity,
@@ -80,8 +101,36 @@ sliced_tree_dict = sliced.to_dict()  # Dict for the optimized sliced tree
 
 ## Rust Quick Start
 
-Two core features are exposed in the quick start below: optimizing contraction
-orders and slicing for lower peak memory.
+`TreeSA::default()` runs the full default pipeline (simplify, anneal,
+splice) with no tuning required. Chain `.with_surgery_budget(30.0)` to spend
+extra wall-clock time (seconds) for a result that's never worse — see the
+[Default Pipeline](https://GiggleLiu.github.io/omeco/algorithms/default-pipeline.html)
+page for what each stage does and when surgery helps:
+
+```rust
+use omeco::{EinCode, TreeSA, optimize_code, contraction_complexity};
+use std::collections::HashMap;
+
+let code = EinCode::new(
+    vec![vec!['i', 'j'], vec!['j', 'k'], vec!['k', 'l']],
+    vec!['i', 'l']
+);
+let mut sizes = HashMap::new();
+sizes.insert('i', 100);
+sizes.insert('j', 200);
+sizes.insert('k', 50);
+sizes.insert('l', 100);
+
+// full default pipeline
+let tree = optimize_code(&code, &sizes, &TreeSA::default()).unwrap();
+// spend time, get a better tree
+let better = optimize_code(&code, &sizes, &TreeSA::default().with_surgery_budget(30.0)).unwrap();
+let complexity = contraction_complexity(&tree, &sizes, &code.ixs);
+println!("Time: 2^{:.2}, Space: 2^{:.2}", complexity.tc, complexity.sc);
+```
+
+Two more core features: optimizing with `GreedyMethod` and slicing for lower
+peak memory.
 
 ```rust
 use omeco::{

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -16,6 +16,7 @@
   - [Exhaustive Search](./algorithms/exhaustive-search.md)
   - [TreeSA](./algorithms/tree-sa.md)
   - [Treewidth](./algorithms/treewidth.md)
+  - [Default Pipeline](./algorithms/default-pipeline.md)
   - [Simplification, Warm-Start, and Waist Surgery](./algorithms/paper-algorithms.md)
   - [Algorithm Comparison](./algorithms/comparison.md)
 

--- a/docs/src/algorithms/default-pipeline.md
+++ b/docs/src/algorithms/default-pipeline.md
@@ -21,9 +21,9 @@ simplify  ->  anneal trials (on the reduced network)  ->  splice  ->  [surgery, 
 3. **Splice** ([`crate::preprocess::splice`]) expands each reduced-network
    leaf back into the binary subtree `simplify` merged it from, so the
    returned tree's leaves are exactly the original tensors again.
-4. **Surgery** ([`crate::waist_surgery::refine`]) only runs if
-   [`TreeSA::surgery_budget`] is greater than `0.0` (the default is `0.0`,
-   off). When enabled, it spends up to that many wall-clock seconds trying to
+4. **Surgery** ([`crate::waist_surgery::refine_capped`]) only runs if
+   [`TreeSA::surgery_iters`] is greater than `0` (the default is `0`, off).
+   When enabled, it runs at most that many surgery iterations trying to
    improve the tree's most expensive contraction (its *waist*) and only keeps
    changes that strictly lower `tc`.
 
@@ -34,30 +34,32 @@ needed to get it.
 ```python
 from omeco import optimize_code, TreeSA
 
-tree = optimize_code(ixs, out, sizes, TreeSA())                        # default pipeline
-better = optimize_code(ixs, out, sizes, TreeSA(surgery_budget=30.0))   # + waist surgery
+tree = optimize_code(ixs, out, sizes, TreeSA())                       # default pipeline
+better = optimize_code(ixs, out, sizes, TreeSA(surgery_iters=20))     # + waist surgery
 ```
 
 ```rust
 use omeco::{optimize_code, TreeSA};
 
 let tree = optimize_code(&code, &sizes, &TreeSA::default()).unwrap();
-let better = optimize_code(&code, &sizes, &TreeSA::default().with_surgery_budget(30.0)).unwrap();
+let better = optimize_code(&code, &sizes, &TreeSA::default().with_surgery_iters(20)).unwrap();
 ```
 
 ## Determinism
 
-- With `surgery_budget: 0.0` (the default), the pipeline's output is
-  **internally seeded, fully deterministic**: simplify, the anneal trials, and
-  splice are all pure functions of the input network (the RNG seeds are fixed
-  internally, not user-supplied), so re-running the same configuration
-  reproduces the same tree on any machine.
-- Setting `surgery_budget > 0.0` trades that reproducibility for quality: the
-  surgery pass is a cooperative, wall-clock-bounded search, so how far it
-  gets — and therefore its exact output — depends on the machine's speed. The
-  result is never worse than without surgery (surgery only ever accepts a
-  strictly cheaper tree), but it is not guaranteed to be *bit-identical*
-  across machines or hardware for the same configuration and budget.
+The whole `TreeSA` API is **fully deterministic and machine-independent**:
+simplify, the anneal trials, splice, and — since `surgery_iters` replaced the
+old wall-clock surgery knob — the surgery post-pass too are all pure
+functions of the input network and config (internal RNG seeds are fixed, and
+no wall-clock deadline binds `optimize_treesa`'s surgery cap). Re-running the
+same configuration reproduces the same tree on any machine, with
+`surgery_iters` at any value: `0` (off), or any positive cap. More iterations
+can only be equal or better, never worse.
+
+Wall-clock budgets still exist, but only on the low-level
+[`crate::waist_surgery::refine`] / [`refine_capped`] APIs (and the Python
+`waist_refine` function) for power users composing their own pipeline outside
+`TreeSA`; see [Simplification, Warm-Start, and Waist Surgery](./paper-algorithms.md).
 
 ## Preprocessing guarantees
 
@@ -100,20 +102,21 @@ only keeps the result if it strictly lowers `tc`.
   a strictly cheaper comparable-balance cut.
 - **Near-no-op elsewhere.** On instances without a frozen waist, surgery's
   bounded search typically returns early after confirming the incumbent cut
-  is locally minimal — you pay a bounded amount of wall-clock time for little
+  is locally minimal — you pay a bounded number of iterations for little
   or no gain, but you
   never regress `tc`.
 
 If you don't know in advance whether your network has this structure, a
-positive `surgery_budget` is a safe default to try: worst case it costs time
-for no improvement, best case it recovers a meaningfully cheaper tree.
+positive `surgery_iters` is a safe default to try: worst case it costs a few
+iterations for no improvement, best case it recovers a meaningfully cheaper
+tree.
 
 ## Escape hatches
 
 | Want | Set |
 |---|---|
 | Skip simplification, anneal the raw network directly | `preprocess: false` (Rust: `.with_preprocess(false)`; Python: `TreeSA(preprocess=False)`) |
-| Skip waist surgery (already the default) | `surgery_budget: 0.0` (Rust: `.with_surgery_budget(0.0)`; Python: `TreeSA(surgery_budget=0.0)`) |
+| Skip waist surgery (already the default) | `surgery_iters: 0` (Rust: `.with_surgery_iters(0)`; Python: `TreeSA(surgery_iters=0)`) |
 
 `TreeSA::path()` sets `preprocess: false` by construction, deliberately —
 `splice` is decomposition-agnostic: it substitutes each reduced-network leaf
@@ -135,4 +138,6 @@ rather than risk it.
 [`crate::preprocess::simplify`]: https://docs.rs/omeco/latest/omeco/preprocess/fn.simplify.html
 [`crate::preprocess::splice`]: https://docs.rs/omeco/latest/omeco/preprocess/fn.splice.html
 [`crate::waist_surgery::refine`]: https://docs.rs/omeco/latest/omeco/waist_surgery/fn.refine.html
-[`TreeSA::surgery_budget`]: https://docs.rs/omeco/latest/omeco/treesa/struct.TreeSA.html#structfield.surgery_budget
+[`crate::waist_surgery::refine_capped`]: https://docs.rs/omeco/latest/omeco/waist_surgery/fn.refine_capped.html
+[`refine_capped`]: https://docs.rs/omeco/latest/omeco/waist_surgery/fn.refine_capped.html
+[`TreeSA::surgery_iters`]: https://docs.rs/omeco/latest/omeco/treesa/struct.TreeSA.html#structfield.surgery_iters

--- a/docs/src/algorithms/default-pipeline.md
+++ b/docs/src/algorithms/default-pipeline.md
@@ -48,15 +48,16 @@ let better = optimize_code(&code, &sizes, &TreeSA::default().with_surgery_budget
 ## Determinism
 
 - With `surgery_budget: 0.0` (the default), the pipeline's output is
-  **seeded-deterministic**: simplify, the anneal trials, and splice are all
-  pure functions of the input network and the RNG seed, so re-running with
-  the same seed reproduces the same tree on any machine.
+  **internally seeded, fully deterministic**: simplify, the anneal trials, and
+  splice are all pure functions of the input network (the RNG seeds are fixed
+  internally, not user-supplied), so re-running the same configuration
+  reproduces the same tree on any machine.
 - Setting `surgery_budget > 0.0` trades that reproducibility for quality: the
   surgery pass is a cooperative, wall-clock-bounded search, so how far it
   gets — and therefore its exact output — depends on the machine's speed. The
   result is never worse than without surgery (surgery only ever accepts a
   strictly cheaper tree), but it is not guaranteed to be *bit-identical*
-  across machines or hardware for the same seed and budget.
+  across machines or hardware for the same configuration and budget.
 
 ## Preprocessing guarantees
 

--- a/docs/src/algorithms/default-pipeline.md
+++ b/docs/src/algorithms/default-pipeline.md
@@ -92,14 +92,15 @@ extracts the tree's most expensive cut, re-optimizes it directly on the
 tensor hypergraph with balance-constrained Fiduccia–Mattheyses passes, and
 only keeps the result if it strictly lowers `tc`.
 
-- **Helps most** on frozen-waist-prone instances: grids and surface-code-like
-  circuits, where the network has genuinely distinct good bipartitions of
-  similar cost that local mutations struggle to reach. On these instance
-  families, roughly 76% (grids) and 31% (surface-code-like circuits) of
-  surgery calls find a strictly cheaper cut.
-- **Near-no-op elsewhere.** On instances without that structure, surgery's
-  bounded search typically finds no cheaper balanced cut and returns early —
-  you pay a bounded amount of wall-clock time for little or no gain, but you
+- **Helps most** on frozen-waist-prone instances, where the network has
+  genuinely distinct good bipartitions of similar cost that local mutations
+  struggle to reach. In the companion paper's measurements, 76% of surgery
+  calls on a surface-code d=21 network and 31% on a king-graph network found
+  a strictly cheaper comparable-balance cut.
+- **Near-no-op elsewhere.** On instances without a frozen waist, surgery's
+  bounded search typically returns early after confirming the incumbent cut
+  is locally minimal — you pay a bounded amount of wall-clock time for little
+  or no gain, but you
   never regress `tc`.
 
 If you don't know in advance whether your network has this structure, a

--- a/docs/src/algorithms/default-pipeline.md
+++ b/docs/src/algorithms/default-pipeline.md
@@ -1,0 +1,136 @@
+# Default Pipeline
+
+Since the flags landed, `TreeSA::default()` (Python: `TreeSA()`) is no longer
+just the annealing loop — it is a small pipeline that wraps annealing with a
+deterministic simplification front-end and an optional, quality-only refinement
+pass. This page documents what runs, what it guarantees, and how to opt out.
+
+## What `TreeSA::default()` runs
+
+```
+simplify  ->  anneal trials (on the reduced network)  ->  splice  ->  [surgery, if budgeted]
+```
+
+1. **Simplify** ([`crate::preprocess::simplify`]) deterministically fuses
+   locally reducible structure — chains of degree-2 tensors, absorbed
+   boundary tensors, and similar neighbours — into a smaller *reduced*
+   network.
+2. **Anneal trials** run the normal TreeSA search loop on that reduced
+   network instead of the raw one, so the search budget is spent where it
+   matters.
+3. **Splice** ([`crate::preprocess::splice`]) expands each reduced-network
+   leaf back into the binary subtree `simplify` merged it from, so the
+   returned tree's leaves are exactly the original tensors again.
+4. **Surgery** ([`crate::waist_surgery::refine`]) only runs if
+   [`TreeSA::surgery_budget`] is greater than `0.0` (the default is `0.0`,
+   off). When enabled, it spends up to that many wall-clock seconds trying to
+   improve the tree's most expensive contraction (its *waist*) and only keeps
+   changes that strictly lower `tc`.
+
+This whole pipeline is what `optimize_code(ixs, out, sizes, TreeSA())` /
+`optimize_code(&code, &sizes, &TreeSA::default())` runs by default — no flags
+needed to get it.
+
+```python
+from omeco import optimize_code, TreeSA
+
+tree = optimize_code(ixs, out, sizes, TreeSA())                        # default pipeline
+better = optimize_code(ixs, out, sizes, TreeSA(surgery_budget=30.0))   # + waist surgery
+```
+
+```rust
+use omeco::{optimize_code, TreeSA};
+
+let tree = optimize_code(&code, &sizes, &TreeSA::default()).unwrap();
+let better = optimize_code(&code, &sizes, &TreeSA::default().with_surgery_budget(30.0)).unwrap();
+```
+
+## Determinism
+
+- With `surgery_budget: 0.0` (the default), the pipeline's output is
+  **seeded-deterministic**: simplify, the anneal trials, and splice are all
+  pure functions of the input network and the RNG seed, so re-running with
+  the same seed reproduces the same tree on any machine.
+- Setting `surgery_budget > 0.0` trades that reproducibility for quality: the
+  surgery pass is a cooperative, wall-clock-bounded search, so how far it
+  gets — and therefore its exact output — depends on the machine's speed. The
+  result is never worse than without surgery (surgery only ever accepts a
+  strictly cheaper tree), but it is not guaranteed to be *bit-identical*
+  across machines or hardware for the same seed and budget.
+
+## Preprocessing guarantees
+
+`simplify` + `splice` come with two guarantees and one deliberate
+non-guarantee — see the [`crate::preprocess`] module docs for the full
+argument:
+
+- **Exactness — yes.** The spliced tree computes the same einsum result as
+  optimizing the original network directly, and every original tensor is
+  still a leaf of the returned tree (`splice` only expands merged
+  super-tensors; it never drops or duplicates a tensor).
+- **Space-safety — yes.** `simplify` only fuses a pair when the resulting
+  intermediate is no larger than its larger input, so the achievable space
+  complexity is never pushed above the original network's floor. Merging can
+  only shrink or hold the peak, never grow it.
+- **tc-optimality — no.** There is no theorem that the eager, local merge
+  rule finds the globally time-optimal reduced network; in principle an
+  eager merge could exclude the true tc-optimum. Empirically this is rare —
+  on structured circuits the pass is a large net win (see below), and on
+  networks with no reducible local structure it is close to a no-op.
+
+On raw Sycamore circuits, simplification shrinks the tensor count by
+~89% before annealing ever runs; on 3-regular random graphs, which carry
+essentially no locally reducible structure, it is a near no-op (the reduced
+network is close to the same size as the original).
+
+## When surgery helps
+
+Waist surgery targets a specific failure mode: local annealing rewrites move
+one subtree at a time and can get stuck unable to jump between two distinct,
+comparably-sized bipartitions of the network — a **frozen waist**. Surgery
+extracts the tree's most expensive cut, re-optimizes it directly on the
+tensor hypergraph with balance-constrained Fiduccia–Mattheyses passes, and
+only keeps the result if it strictly lowers `tc`.
+
+- **Helps most** on frozen-waist-prone instances: grids and surface-code-like
+  circuits, where the network has genuinely distinct good bipartitions of
+  similar cost that local mutations struggle to reach. On these instance
+  families, roughly 76% (grids) and 31% (surface-code-like circuits) of
+  surgery calls find a strictly cheaper cut.
+- **Near-no-op elsewhere.** On instances without that structure, surgery's
+  bounded search typically finds no cheaper balanced cut and returns early —
+  you pay a bounded amount of wall-clock time for little or no gain, but you
+  never regress `tc`.
+
+If you don't know in advance whether your network has this structure, a
+positive `surgery_budget` is a safe default to try: worst case it costs time
+for no improvement, best case it recovers a meaningfully cheaper tree.
+
+## Escape hatches
+
+| Want | Set |
+|---|---|
+| Skip simplification, anneal the raw network directly | `preprocess: false` (Rust: `.with_preprocess(false)`; Python: `TreeSA(preprocess=False)`) |
+| Skip waist surgery (already the default) | `surgery_budget: 0.0` (Rust: `.with_surgery_budget(0.0)`; Python: `TreeSA(surgery_budget=0.0)`) |
+
+`TreeSA::path()` sets `preprocess: false` by construction, deliberately —
+`splice` is decomposition-agnostic: it substitutes each reduced-network leaf
+with whatever binary subtree `simplify` produced for it, which is not
+path-shaped in general. Running the front-end under `path()` could give the
+spliced tree a node with two non-leaf children and break that preset's
+documented linear-contraction-order guarantee, so it opts out unconditionally
+rather than risk it.
+
+## See also
+
+- [Simplification, Warm-Start, and Waist Surgery](./paper-algorithms.md) —
+  the lower-level building blocks (`simplify_then_optimize`, `refine`,
+  warm-start annealing) if you want to compose your own pipeline instead of
+  the managed default.
+- [TreeSA](./tree-sa.md) — the annealing search itself and its tuning knobs.
+
+[`crate::preprocess`]: https://docs.rs/omeco/latest/omeco/preprocess/index.html
+[`crate::preprocess::simplify`]: https://docs.rs/omeco/latest/omeco/preprocess/fn.simplify.html
+[`crate::preprocess::splice`]: https://docs.rs/omeco/latest/omeco/preprocess/fn.splice.html
+[`crate::waist_surgery::refine`]: https://docs.rs/omeco/latest/omeco/waist_surgery/fn.refine.html
+[`TreeSA::surgery_budget`]: https://docs.rs/omeco/latest/omeco/treesa/struct.TreeSA.html#structfield.surgery_budget

--- a/docs/superpowers/plans/2026-07-29-usability-post-alignment.md
+++ b/docs/superpowers/plans/2026-07-29-usability-post-alignment.md
@@ -1,0 +1,637 @@
+# Post-Alignment Usability Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the paper pipeline (preprocess → TreeSA → optional waist surgery) the flags-on-TreeSA default path in Rust and Python, and retire the Julia behavioral-alignment rule.
+
+**Architecture:** `TreeSA` gains `preprocess: bool` (default true) and `surgery_budget: f64` seconds (default 0.0). `optimize_treesa` wraps its existing trial loop (renamed `optimize_treesa_core`) with simplify/splice and an optional `refine` post-pass. Python mirrors the flags and additionally exposes `simplify_then_optimize` / `waist_refine` with report types. Docs and CLAUDE.md updated; patch version bump.
+
+**Tech Stack:** Rust (edition 2021, MSRV 1.70, clippy -D warnings), PyO3/maturin via `make python-dev`, pytest, mdBook.
+
+## Global Constraints
+
+- Spec: `docs/superpowers/specs/2026-07-29-usability-post-alignment-design.md` (same repo).
+- Worktree: `/private/tmp/claude-501/-Users-liujinguo-rcode-omeco/ec429751-cbe2-44e2-a096-1ead2502c7b2/scratchpad/usability`, branch `jg/usability`, base = master `6b3d95c`.
+- Defaults exactly: `preprocess: true`, `surgery_budget: 0.0`.
+- No panics/unwraps in production code; doc comments with runnable examples on all public items.
+- Gate before every commit that touches Rust: `make check-all` (fmt + clippy + tests). Python tasks: `make python-dev && make python-test`.
+- JSON interop with Julia unchanged. `GreedyMethod`, `Treewidth`, `TreeSASlicer`, `ExhaustiveSearch` behavior unchanged.
+- Do not modify `research/**` or `articles/**`.
+
+---
+
+### Task 1: `Ord` as a `Label` supertrait
+
+`preprocess::simplify` requires `L: Ord` for determinism; `optimize_treesa` is generic over `L: Label` through the `CodeOptimizer` trait, whose signature cannot add bounds per-impl. Fold `Ord` into `Label`.
+
+**Files:**
+- Modify: `omeco/src/label.rs:22` (trait bound)
+- Modify: `omeco/src/preprocess.rs` (drop now-redundant `+ Ord` bounds on `simplify`, `simplify_then_optimize`)
+
+**Interfaces:**
+- Produces: `pub trait Label: Clone + Eq + Ord + Hash + Debug + Send + Sync + 'static {}` — later tasks call `simplify::<L: Label>` without extra bounds.
+
+- [ ] **Step 1: Change the trait**
+
+In `omeco/src/label.rs` replace:
+
+```rust
+pub trait Label: Clone + Eq + Hash + Debug + Send + Sync + 'static {}
+```
+
+with:
+
+```rust
+pub trait Label: Clone + Eq + Ord + Hash + Debug + Send + Sync + 'static {}
+```
+
+Every provided impl (`char`, `u8`–`u64`, `usize`, `i8`–`i64`, `isize`, `String`, whatever the file lists) already satisfies `Ord`; leave the impls untouched. Update the trait's doc comment to mention `Ord` (needed by deterministic preprocessing).
+
+- [ ] **Step 2: Drop redundant bounds**
+
+In `omeco/src/preprocess.rs` change `pub fn simplify<L: Label + Ord>` → `pub fn simplify<L: Label>` and `pub fn simplify_then_optimize<L: Label + Ord, O: CodeOptimizer>` → `pub fn simplify_then_optimize<L: Label, O: CodeOptimizer>`. Update the doc sentence "requires `L: Ord` for that determinism" to say `Ord` comes with `Label`.
+
+- [ ] **Step 3: Run the gate**
+
+Run: `make check-all`
+Expected: clean (this is a pure widening for all in-repo label types).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add omeco/src/label.rs omeco/src/preprocess.rs
+git commit -m "Label: require Ord (needed by deterministic preprocessing)"
+```
+
+---
+
+### Task 2: TreeSA config fields
+
+**Files:**
+- Modify: `omeco/src/treesa.rs:18-33` (struct), `:44-57` (Default), `:59-96` (new/fast/path), builder-setter block below them
+- Modify: `omeco/src/treesa.rs` tests that construct `TreeSA { ... }` literally (`test_trial_selection_ranks_by_emitted_tree_cost` around line 845 builds a full literal — give it `preprocess: false, surgery_budget: 0.0` so it keeps testing the bare trial loop)
+- Test: inline `#[cfg(test)]` in `omeco/src/treesa.rs`
+
+**Interfaces:**
+- Produces: `TreeSA { pub preprocess: bool, pub surgery_budget: f64, /* existing fields */ }`; `TreeSA::with_preprocess(bool) -> Self`; `TreeSA::with_surgery_budget(f64) -> Self`. Task 3/4 read `config.preprocess` / `config.surgery_budget`; Task 6 sets both from Python.
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+#[test]
+fn test_treesa_pipeline_defaults() {
+    let config = TreeSA::default();
+    assert!(config.preprocess);
+    assert_eq!(config.surgery_budget, 0.0);
+    let fast = TreeSA::fast();
+    assert!(fast.preprocess);
+    assert_eq!(fast.surgery_budget, 0.0);
+    let tuned = TreeSA::default()
+        .with_preprocess(false)
+        .with_surgery_budget(30.0);
+    assert!(!tuned.preprocess);
+    assert_eq!(tuned.surgery_budget, 30.0);
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p omeco --lib test_treesa_pipeline_defaults`
+Expected: compile error — no field `preprocess`.
+
+- [ ] **Step 3: Implement**
+
+Add to the struct (with doc comments):
+
+```rust
+    /// Run the structural simplification front-end before annealing
+    /// (simplify → optimize the reduced network → splice back). Deterministic
+    /// and exactness-preserving; see [`crate::preprocess`].
+    pub preprocess: bool,
+    /// Wall-clock budget in seconds for the waist-surgery post-pass on the
+    /// selected tree; `0.0` disables it. With a positive budget the result is
+    /// never worse than without, but is not reproducible across machines.
+    /// See [`crate::waist_surgery`].
+    pub surgery_budget: f64,
+```
+
+`Default`: add `preprocess: true, surgery_budget: 0.0`. `TreeSA::new` builds a full literal — append the same two defaults there. `fast()` and `path()` use `..Default::default()`, so they inherit automatically. Add builder setters next to `with_ntrials`:
+
+```rust
+    /// Enable or disable the structural simplification front-end.
+    pub fn with_preprocess(mut self, preprocess: bool) -> Self {
+        self.preprocess = preprocess;
+        self
+    }
+
+    /// Set the waist-surgery wall-clock budget in seconds (0.0 disables).
+    pub fn with_surgery_budget(mut self, seconds: f64) -> Self {
+        self.surgery_budget = seconds;
+        self
+    }
+```
+
+Fix the full-literal test construction in `test_trial_selection_ranks_by_emitted_tree_cost` by adding `preprocess: false, surgery_budget: 0.0,` to its `TreeSA { ... }`.
+
+- [ ] **Step 4: Run the gate**
+
+Run: `make check-all`
+Expected: clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add omeco/src/treesa.rs
+git commit -m "TreeSA: preprocess and surgery_budget config fields"
+```
+
+---
+
+### Task 3: Preprocess stage in `optimize_treesa`
+
+**Files:**
+- Modify: `omeco/src/treesa.rs:658` region — rename the existing `pub fn optimize_treesa` body to a private `fn optimize_treesa_core` with the identical signature, and add a new `pub fn optimize_treesa` wrapper
+- Test: inline tests in `omeco/src/treesa.rs`
+
+**Interfaces:**
+- Consumes: `crate::preprocess::{simplify, splice}` (`simplify(&EinCode<L>, &HashMap<L, usize>) -> Simplified<L>` with fields `code`, `subtrees`, `report`; `splice(&NestedEinsum<L>, &[NestedEinsum<L>]) -> NestedEinsum<L>`).
+- Produces: `optimize_treesa` honoring `config.preprocess`; `optimize_treesa_core` for Task 4's test to call the bare loop.
+
+- [ ] **Step 1: Write the failing tests**
+
+```rust
+#[test]
+fn test_default_pipeline_preprocess_preserves_interfaces() {
+    // Matrix chain: simplify collapses it; the spliced tree must keep all leaves.
+    let code = EinCode::new(
+        vec![vec!['a', 'b'], vec!['b', 'c'], vec!['c', 'd'], vec!['d', 'e']],
+        vec!['a', 'e'],
+    );
+    let sizes: HashMap<char, usize> =
+        [('a', 2), ('b', 2), ('c', 2), ('d', 2), ('e', 2)].into();
+    let tree = optimize_treesa(&code, &sizes, &TreeSA::fast()).unwrap();
+    assert_eq!(tree.leaf_count(), 4);
+    let cc = crate::contraction_complexity(&tree, &sizes, &code.ixs);
+    assert!(cc.tc.is_finite());
+}
+
+#[test]
+fn test_default_pipeline_quality_on_benchmark_graphs() {
+    // Spec §4: default (preprocess on) is within 0.5 bits of the bare loop on
+    // the benchmark graphs; exact equality where simplify is a no-op (reg3).
+    for (name, no_op) in [("grid_4x4", false), ("reg3_50", true)] {
+        let graph_json = std::fs::read_to_string(format!("../benchmarks/graphs/{name}.json")).unwrap();
+        let graph: serde_json::Value = serde_json::from_str(&graph_json).unwrap();
+        let mut ixs: Vec<Vec<usize>> = Vec::new();
+        for edge in graph["edge_list"].as_array().unwrap() {
+            let a = edge.as_array().unwrap();
+            ixs.push(vec![a[0].as_u64().unwrap() as usize, a[1].as_u64().unwrap() as usize]);
+        }
+        // line-graph convention used by the other benchmark tests: tensors are
+        // vertices, labels are edge endpoints — mirror test_reg3_220_treesa's
+        // construction in omeco/src/lib.rs if it differs from the above.
+        let code = EinCode::new(ixs, vec![]);
+        let sizes: HashMap<usize, usize> =
+            code.unique_labels().into_iter().map(|l| (l, 2)).collect();
+        let cfg = TreeSA::fast();
+        let with_pre = optimize_treesa(&code, &sizes, &cfg).unwrap();
+        let without = optimize_treesa(&code, &sizes, &cfg.clone().with_preprocess(false)).unwrap();
+        let tc_pre = crate::contraction_complexity(&with_pre, &sizes, &code.ixs).tc;
+        let tc_raw = crate::contraction_complexity(&without, &sizes, &code.ixs).tc;
+        if no_op {
+            assert!((tc_pre - tc_raw).abs() < 1e-9, "{name}: {tc_pre} vs {tc_raw}");
+        } else {
+            assert!(tc_pre <= tc_raw + 0.5, "{name}: {tc_pre} > {tc_raw} + 0.5");
+        }
+    }
+}
+
+#[test]
+fn test_preprocess_off_matches_core_loop() {
+    let code = EinCode::new(
+        vec![vec!['a', 'b'], vec!['b', 'c'], vec!['c', 'a']],
+        Vec::<char>::new(),
+    );
+    let sizes: HashMap<char, usize> = [('a', 4), ('b', 4), ('c', 4)].into();
+    let config = TreeSA::fast().with_preprocess(false);
+    let via_public = optimize_treesa(&code, &sizes, &config).unwrap();
+    let via_core = optimize_treesa_core(&code, &sizes, &config).unwrap();
+    assert_eq!(
+        format!("{via_public:?}"), format!("{via_core:?}"),
+        "preprocess=false must be byte-identical to the bare trial loop"
+    );
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cargo test -p omeco --lib test_preprocess_off_matches_core_loop`
+Expected: compile error — `optimize_treesa_core` not defined.
+
+- [ ] **Step 3: Implement**
+
+Rename the current function to `fn optimize_treesa_core<L: Label>(...)` (same body, same signature, not `pub`). Add:
+
+```rust
+/// Optimize an EinCode using TreeSA.
+///
+/// By default this runs the full pipeline: structural simplification
+/// ([`crate::preprocess::simplify`]), the annealing trial loop on the reduced
+/// network, and splice-back — controlled by [`TreeSA::preprocess`]. A positive
+/// [`TreeSA::surgery_budget`] additionally refines the result with
+/// [`crate::waist_surgery::refine`].
+pub fn optimize_treesa<L: Label>(
+    code: &EinCode<L>,
+    size_dict: &HashMap<L, usize>,
+    config: &TreeSA,
+) -> Option<NestedEinsum<L>> {
+    let tree = if config.preprocess {
+        let simplified = simplify(code, size_dict);
+        let reduced = optimize_treesa_core(&simplified.code, size_dict, config)?;
+        splice(&reduced, &simplified.subtrees)
+    } else {
+        optimize_treesa_core(code, size_dict, config)?
+    };
+    Some(tree)
+}
+```
+
+Move the existing doc comment (plus the pipeline paragraph above) onto the wrapper; add `use crate::preprocess::{simplify, splice};` to the imports. Keep the existing `# Example` doc test on the wrapper.
+
+Note: `simplify` on a 0- or 1-tensor code returns it unchanged with the leaf subtree, and `optimize_treesa_core` already handles those sizes, so no new edge-case code.
+
+- [ ] **Step 4: Run the gate**
+
+Run: `make check-all`
+Expected: clean. If any pre-existing treesa test asserting an exact tree fails under the new default, set `preprocess: false` is NOT the fix — first check whether the test's network is simplifiable; only where it is, update the expectation deliberately with a comment citing this plan, one test per commit hunk. (The tolerance-based `test_reg3_220_treesa` at `omeco/src/lib.rs:1296` asserts `sc <= 32` and is expected to keep passing.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add omeco/src/treesa.rs
+git commit -m "TreeSA: preprocessing front-end on by default"
+```
+
+---
+
+### Task 4: Surgery stage in `optimize_treesa`
+
+**Files:**
+- Modify: `omeco/src/treesa.rs` (wrapper from Task 3)
+- Test: inline tests in `omeco/src/treesa.rs`
+
+**Interfaces:**
+- Consumes: `crate::waist_surgery::refine(&NestedEinsum<L>, &EinCode<L>, &HashMap<L, usize>, Duration) -> (NestedEinsum<L>, WaistReport)`.
+- Produces: final `optimize_treesa` behavior for Task 6's Python bindings.
+
+- [ ] **Step 1: Write the failing tests**
+
+```rust
+#[test]
+fn test_surgery_budget_never_worse() {
+    // 4x4 periodic grid — a frozen-waist-style instance where surgery acts.
+    let code = grid_code(4, 4); // helper below
+    let sizes: HashMap<usize, usize> =
+        code.unique_labels().into_iter().map(|l| (l, 2)).collect();
+    let base_cfg = TreeSA::fast();
+    let base = optimize_treesa(&code, &sizes, &base_cfg).unwrap();
+    let base_tc = crate::contraction_complexity(&base, &sizes, &code.ixs).tc;
+    let cfg = TreeSA::fast().with_surgery_budget(2.0);
+    let refined = optimize_treesa(&code, &sizes, &cfg).unwrap();
+    let refined_tc = crate::contraction_complexity(&refined, &sizes, &code.ixs).tc;
+    assert!(refined_tc <= base_tc + 1e-9, "{refined_tc} > {base_tc}");
+    assert_eq!(refined.leaf_count(), code.num_tensors());
+}
+
+#[test]
+fn test_surgery_off_is_reproducible() {
+    let code = EinCode::new(
+        vec![vec![0usize, 1], vec![1, 2], vec![2, 3], vec![3, 0]],
+        vec![],
+    );
+    let sizes: HashMap<usize, usize> = (0..4).map(|l| (l, 8)).collect();
+    let cfg = TreeSA::fast(); // surgery_budget == 0.0
+    let a = optimize_treesa(&code, &sizes, &cfg).unwrap();
+    let b = optimize_treesa(&code, &sizes, &cfg).unwrap();
+    assert_eq!(format!("{a:?}"), format!("{b:?}"));
+}
+```
+
+`grid_code(rows, cols)` helper (put next to the tests): build a periodic 2D grid where every horizontal/vertical neighbor pair shares a fresh label id — 16 tensors of rank 4; copy the shape of `waist_surgery`'s own `grid` test helper (`omeco/src/waist_surgery.rs`, `mod tests`, fn `grid`) rather than inventing a new topology.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+The never-worse assertion can pass vacuously before the wiring exists, so
+make the red observable: add this temporary assertion as the test's last
+line, remove it in Step 3 once wiring lands:
+
+```rust
+    // RED marker: fails until optimize_treesa consumes surgery_budget.
+    let calls_grep = std::fs::read_to_string("src/treesa.rs").unwrap();
+    assert!(calls_grep.contains("waist_surgery::refine"),
+        "optimize_treesa does not call refine yet");
+```
+
+Run: `cargo test -p omeco --lib test_surgery_budget_never_worse`
+Expected: FAIL on the RED marker assertion.
+
+- [ ] **Step 3: Implement**
+
+In the Task-3 wrapper, before `Some(tree)`:
+
+```rust
+    if config.surgery_budget > 0.0 {
+        let budget = std::time::Duration::from_secs_f64(config.surgery_budget);
+        let (refined, _report) = crate::waist_surgery::refine(&tree, code, size_dict, budget);
+        return Some(refined);
+    }
+```
+
+- [ ] **Step 4: Run the gate**
+
+Run: `make check-all`
+Expected: clean; the two new tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add omeco/src/treesa.rs
+git commit -m "TreeSA: opt-in waist-surgery post-pass via surgery_budget"
+```
+
+---
+
+### Task 5: Python bindings
+
+**Files:**
+- Modify: `omeco-python/src/lib.rs:546-548` (`PyTreeSA::new` signature), `:576-581` (`fast`), getters block, `:799` (`optimize_treesa` default construction), module registration at the bottom (`add_class`/`add_function` list)
+- Test: `omeco-python/tests/test_pipeline.py` (new)
+
+**Interfaces:**
+- Consumes: Rust `TreeSA` fields from Task 2; `preprocess::simplify_then_optimize`, `waist_surgery::refine`, `SimplifyReport { n_original, n_reduced, shrink }`, `WaistReport { n_original, surgery_calls, cheaper_cuts, rebuild_attempts, rebuild_accepts, waist_min_hits }`.
+- Produces (Python API): `TreeSA(ntrials=10, niters=50, betas=None, score=None, preprocess=True, surgery_budget=0.0)` with matching getters; `simplify_then_optimize(ixs, out, sizes, optimizer) -> (NestedEinsum, SimplifyReport)`; `waist_refine(tree, ixs, out, sizes, budget_secs) -> (NestedEinsum, WaistReport)`.
+
+- [ ] **Step 1: Write the failing tests**
+
+`omeco-python/tests/test_pipeline.py`:
+
+```python
+from omeco import (
+    TreeSA, GreedyMethod, optimize_code, contraction_complexity,
+    simplify_then_optimize, waist_refine,
+)
+
+CHAIN_IXS = [[0, 1], [1, 2], [2, 3], [3, 4]]
+CHAIN_OUT = [0, 4]
+CHAIN_SIZES = {i: 2 for i in range(5)}
+
+
+def test_treesa_pipeline_defaults():
+    opt = TreeSA()
+    assert opt.preprocess is True
+    assert opt.surgery_budget == 0.0
+    opt2 = TreeSA(preprocess=False, surgery_budget=1.5)
+    assert opt2.preprocess is False
+    assert opt2.surgery_budget == 1.5
+
+
+def test_treesa_default_keeps_all_leaves():
+    tree = optimize_code(CHAIN_IXS, CHAIN_OUT, CHAIN_SIZES, TreeSA(ntrials=1, niters=5))
+    assert tree.leaf_count() == 4
+
+
+def test_simplify_then_optimize_reports_shrink():
+    tree, report = simplify_then_optimize(CHAIN_IXS, CHAIN_OUT, CHAIN_SIZES, GreedyMethod())
+    assert tree.leaf_count() == 4
+    assert report.n_original == 4
+    assert report.n_reduced <= report.n_original
+
+
+def test_waist_refine_never_worse():
+    seed = optimize_code(CHAIN_IXS, CHAIN_OUT, CHAIN_SIZES, GreedyMethod())
+    seed_tc = contraction_complexity(seed, CHAIN_IXS, CHAIN_SIZES).tc
+    refined, report = waist_refine(seed, CHAIN_IXS, CHAIN_OUT, CHAIN_SIZES, 0.5)
+    tc = contraction_complexity(refined, CHAIN_IXS, CHAIN_SIZES).tc
+    assert tc <= seed_tc + 1e-9
+    assert report.surgery_calls >= 0
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `make python-dev && make python-test`
+Expected: `test_pipeline.py` fails — `TreeSA() got an unexpected keyword` / import errors for the two functions.
+
+- [ ] **Step 3: Implement**
+
+1. `PyTreeSA::new`: signature `(ntrials=10, niters=50, betas=None, score=None, preprocess=true, surgery_budget=0.0)`; set the two fields on `inner` (the constructor already uses a struct literal with `..Default::default()` — set explicitly from the arguments). Add `#[getter] preprocess() -> bool` and `#[getter] surgery_budget() -> f64`. `fast()` keeps defaults via `TreeSA::fast()`.
+2. Update the `optimize_treesa` pyfunction's fallback `PyTreeSA::new(10, 50, None, None)` call to the new arity `PyTreeSA::new(10, 50, None, None, true, 0.0)`.
+3. New pyclasses, following the `PyContractionComplexity` pattern in the same file (plain `#[pyclass]` with `#[getter]`s and `__repr__`):
+
+```rust
+#[pyclass(name = "SimplifyReport")]
+#[derive(Clone)]
+pub struct PySimplifyReport { inner: omeco::preprocess::SimplifyReport }
+// getters: n_original -> usize, n_reduced -> usize, shrink -> f64
+// __repr__: format!("SimplifyReport(n_original={}, n_reduced={}, shrink={:.3})", ...)
+
+#[pyclass(name = "WaistReport")]
+#[derive(Clone)]
+pub struct PyWaistReport { inner: omeco::waist_surgery::WaistReport }
+// getters for all six u64/usize counter fields; __repr__ listing them
+```
+
+4. New pyfunctions (mirror `optimize_treesa`'s i64 conversion style):
+
+```rust
+#[pyfunction]
+#[pyo3(signature = (ixs, out, sizes, optimizer=None))]
+fn simplify_then_optimize(
+    ixs: Vec<Vec<i64>>, out: Vec<i64>, sizes: HashMap<i64, usize>,
+    optimizer: Option<PyGreedyMethod>,
+) -> PyResult<(PyNestedEinsum, PySimplifyReport)> {
+    let code = EinCode::new(ixs, out);
+    let opt = optimizer.map(|o| o.inner).unwrap_or_default();
+    omeco::preprocess::simplify_then_optimize(&code, &sizes, &opt)
+        .map(|(t, r)| (PyNestedEinsum { inner: t }, PySimplifyReport { inner: r }))
+        .ok_or_else(|| PyValueError::new_err("optimization failed"))
+}
+
+#[pyfunction]
+fn waist_refine(
+    tree: PyNestedEinsum, ixs: Vec<Vec<i64>>, out: Vec<i64>,
+    sizes: HashMap<i64, usize>, budget_secs: f64,
+) -> PyResult<(PyNestedEinsum, PyWaistReport)> {
+    if !budget_secs.is_finite() || budget_secs < 0.0 {
+        return Err(PyValueError::new_err("budget_secs must be a non-negative finite number"));
+    }
+    let code = EinCode::new(ixs, out);
+    let (t, r) = omeco::waist_surgery::refine(
+        &tree.inner, &code, &sizes, std::time::Duration::from_secs_f64(budget_secs),
+    );
+    Ok((PyNestedEinsum { inner: t }, PyWaistReport { inner: r }))
+}
+```
+
+(`simplify_then_optimize` takes a `GreedyMethod` optimizer argument only — the generic `O: CodeOptimizer` cannot cross PyO3; Greedy is the documented inner optimizer for the reduced network, and TreeSA users get preprocessing via the flag instead. State this in the docstring.)
+
+5. Register: `m.add_class::<PySimplifyReport>()?;`, `m.add_class::<PyWaistReport>()?;`, `m.add_function(wrap_pyfunction!(simplify_then_optimize, m)?)?;`, `m.add_function(wrap_pyfunction!(waist_refine, m)?)?;`. Add both names to `omeco-python`'s `__init__.py` re-export list if one exists (check `omeco-python/python/omeco/__init__.py` or equivalent; mirror how `optimize_treesa` is exported).
+
+- [ ] **Step 4: Run the gates**
+
+Run: `make python-dev && make python-test` then `make check-all`
+Expected: all green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add omeco-python
+git commit -m "Python: TreeSA pipeline flags, simplify_then_optimize, waist_refine"
+```
+
+---
+
+### Task 6: Retire the alignment rule (CLAUDE.md, README, test marker)
+
+**Files:**
+- Modify: `.claude/CLAUDE.md` (sections listed below)
+- Modify: `README.md` (positioning line)
+- Modify: `omeco/src/lib.rs:1296-1310` (marker comment only)
+
+**Interfaces:** none (docs/policy).
+
+Note: no GitHub workflow actually gates on Julia (verified — `grep -l julia
+.github/workflows/*` matches nothing; only the Makefile has a Julia
+benchmark target), so the spec's "demote the CI Julia gate" reduces to
+deleting the CLAUDE.md sentence claiming that gate exists.
+
+- [ ] **Step 1: Rewrite CLAUDE.md**
+
+Replace the `## CRITICAL: Alignment with Julia OMEinsumContractionOrders` section (lines ~8-20) with:
+
+```markdown
+## Relationship to Julia OMEinsumContractionOrders
+
+omeco originated as a port of
+[OMEinsumContractionOrders.jl](https://github.com/TensorBFS/OMEinsumContractionOrders.jl)
+and keeps **JSON interop** (`writejson`/`readjson`) as a compatibility
+contract. Behavior and defaults are independent: changes are judged on
+omeco's own results and ergonomics, not parity with Julia. The Julia
+implementation at `~/.julia/dev/OMEinsumContractionOrders/` remains a
+useful reference when porting algorithms.
+```
+
+In the Testing section: delete the line "**Always compare results with Julia implementation**" and the "CRITICAL: Do NOT modify existing tests… ALIGNED WITH JULIA" sentence; replace with "Do not weaken existing regression tests to make a change pass; update expectations only with a comment explaining the behavior change." In CI Requirements: delete "**Benchmark tc values must match Julia within tolerance**". In Benchmarks/Expected Results and Debugging sections: keep the Julia comparison instructions but reword "should match Julia within" → "can be compared against Julia with" (informational).
+
+- [ ] **Step 2: Update the test marker and README**
+
+In `omeco/src/lib.rs` `test_reg3_220_treesa`, change the banner comment `ALIGNED WITH JULIA - DO NOT MODIFY WITHOUT CHECKING JULIA TESTS` to `REGRESSION (originally cross-checked against Julia test/treesa.jl)` — keep the assertion and provenance notes. In `README.md`, change "ported from" to "originated as a port of" in the opening description.
+
+- [ ] **Step 3: Run the gate**
+
+Run: `make check-all`
+Expected: clean (comment/doc changes only).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .claude/CLAUDE.md README.md omeco/src/lib.rs
+git commit -m "Retire the Julia behavioral-alignment rule (JSON interop stays)"
+```
+
+---
+
+### Task 7: Documentation (README quickstart, mdBook page, rustdoc check)
+
+**Files:**
+- Modify: `README.md` (Python and Rust quickstart blocks, lines ~54-133)
+- Create: `docs/src/algorithms/default-pipeline.md`
+- Modify: `docs/src/SUMMARY.md` (add the page above `paper-algorithms.md`'s entry)
+
+**Interfaces:** consumes the Task 2-5 API exactly as named there.
+
+- [ ] **Step 1: README quickstart**
+
+Lead the Python block with the default path and the budget knob:
+
+```python
+from omeco import optimize_code, contraction_complexity, TreeSA
+
+ixs = [[0, 1], [1, 2], [2, 3]]
+out = [0, 3]
+sizes = {0: 100, 1: 200, 2: 50, 3: 100}
+
+tree = optimize_code(ixs, out, sizes, TreeSA())        # full default pipeline
+better = optimize_code(ixs, out, sizes, TreeSA(surgery_budget=30.0))  # spend time, get a better tree
+print(contraction_complexity(tree, ixs, sizes))
+```
+
+Keep the existing Greedy/slicing content below it. Mirror the two-line story in the Rust block (`TreeSA::default()` / `.with_surgery_budget(30.0)`).
+
+- [ ] **Step 2: mdBook page**
+
+`docs/src/algorithms/default-pipeline.md` — sections: (1) what `TreeSA::default()` runs, with the stage list simplify → anneal trials → splice → optional surgery; (2) determinism: default output is seeded-deterministic; `surgery_budget > 0` trades reproducibility for quality (never worse, machine-dependent); (3) preprocessing guarantees — exactness yes, space-safety yes (each merged intermediate is no larger than its larger input, so sc is never pushed above the original network's floor), tc-optimality no (cite the module docs); (4) when surgery helps — frozen-waist instances (grids, surface-code-like circuits), near-no-op elsewhere; (5) escape hatches table: `preprocess: false`, `surgery_budget: 0.0`. Register in `SUMMARY.md`.
+
+- [ ] **Step 3: Build the book and docs**
+
+Run: `make build-book` and `cargo doc -p omeco --no-deps 2>&1 | grep -i warn; true`
+Expected: book builds; no new rustdoc warnings.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add README.md docs/src
+git commit -m "Docs: default-pipeline page and quickstart for the new flags"
+```
+
+---
+
+### Task 8: Changelog and patch version bump
+
+**Files:**
+- Create: `CHANGELOG.md` (if absent; otherwise prepend)
+- Version bump via `make bump-patch` (bumps 0.2.6 → 0.2.7 across Cargo/pyproject and commits)
+
+**Interfaces:** none.
+
+- [ ] **Step 1: Changelog entry**
+
+```markdown
+# Changelog
+
+## 0.2.7 — 2026-07-29
+
+**Default behavior change:** `TreeSA` now runs the structural
+simplification front-end by default (`preprocess: true`) — output trees
+may differ from 0.2.6 (same contraction result, typically equal or better
+cost). Restore the old behavior with `preprocess: false`.
+
+- New `TreeSA.surgery_budget` (seconds, default 0.0/off): opt-in
+  waist-surgery post-pass; never worse than the unrefined tree, wall-clock
+  dependent.
+- Python: `TreeSA(preprocess=..., surgery_budget=...)`,
+  `simplify_then_optimize`, `waist_refine`, `SimplifyReport`, `WaistReport`.
+- `Label` now requires `Ord` (all built-in label types already qualify).
+- The Julia behavioral-alignment rule is retired; JSON interop is unchanged.
+```
+
+Commit: `git add CHANGELOG.md && git commit -m "Changelog for 0.2.7"`
+
+- [ ] **Step 2: Bump**
+
+Run: `make bump-patch`
+Expected: version 0.2.7 committed by the make target.
+
+- [ ] **Step 3: Final gate**
+
+Run: `make check-all && make python-dev && make python-test && make build-book`
+Expected: everything green.
+
+- [ ] **Step 4: Push and open PR**
+
+```bash
+git push -u origin jg/usability
+gh pr create -R GiggleLiu/omeco --base master --title "TreeSA pipeline flags: preprocess default, opt-in surgery; retire Julia alignment" \
+  --body "Implements docs/superpowers/specs/2026-07-29-usability-post-alignment-design.md. Default change: preprocess=true (changelog). surgery_budget opt-in. Python parity + simplify_then_optimize/waist_refine. Alignment rule retired, JSON interop kept. Patch bump 0.2.7."
+```
+
+Do not merge; the maintainer approves.

--- a/docs/superpowers/specs/2026-07-29-usability-post-alignment-design.md
+++ b/docs/superpowers/specs/2026-07-29-usability-post-alignment-design.md
@@ -1,0 +1,137 @@
+# omeco post-alignment usability design
+
+Date: 2026-07-29. Approved by the maintainer in-session.
+
+## Goal
+
+Make the paper's algorithms (structural preprocessing, waist surgery)
+reachable from the default user path in both Rust and Python, and retire the
+Julia behavioral-alignment constraint that previously prevented this.
+
+## Decisions (user-confirmed)
+
+1. **Rule scope — full freedom.** omeco is independent: behavior and defaults
+   may diverge from OMEinsumContractionOrders.jl when it improves results or
+   ergonomics. JSON `writejson`/`readjson` interop with Julia remains a
+   compatibility contract (file format, not behavior).
+2. **API shape — flags on TreeSA.** No new pipeline type; `TreeSA` gains the
+   pipeline stages as config fields.
+3. **Defaults.** `preprocess: true` (deterministic, exactness-preserving, big
+   wins on circuit-like networks, near-no-op elsewhere — output trees differ
+   from 0.2.x). `surgery_budget: 0.0` (off — consistent with previous
+   behavior; surgery is wall-clock-dependent so it stays opt-in).
+
+## 1. API
+
+### Rust
+
+```rust
+pub struct TreeSA {
+    // existing fields unchanged: betas, ntrials, niters, score,
+    // decomposition_type, initializer
+    /// Run the structural simplification front-end (simplify -> optimize the
+    /// reduced network -> splice). Deterministic and exactness-preserving.
+    pub preprocess: bool,        // default: true
+    /// Wall-clock budget in seconds for the waist-surgery post-pass on the
+    /// selected tree. 0.0 disables it. Results with surgery enabled are
+    /// never worse than without, but are not reproducible across machines.
+    pub surgery_budget: f64,     // default: 0.0
+}
+```
+
+`optimize_treesa` becomes, in order:
+
+1. If `preprocess`: `simplify(code)`, run the existing trial loop on the
+   reduced code, `splice` back. Otherwise run the trial loop directly.
+2. If `surgery_budget > 0.0`: `waist_surgery::refine(tree, code, sizes,
+   Duration::from_secs_f64(surgery_budget))`, return the refined tree.
+
+Quality is monotone across stages: splice preserves exactness; `refine`
+independently rescores and accepts only strict global improvements.
+
+Presets: `TreeSA::default()` = `{preprocess: true, surgery_budget: 0.0}`;
+`TreeSA::fast()` keeps the same two values. Builder-style setters
+(`with_preprocess`, `with_surgery_budget`) for non-Python callers.
+
+Unchanged: `GreedyMethod`, `Treewidth`, `TreeSASlicer`, `ExhaustiveSearch`,
+JSON I/O, the standalone `preprocess::*` and `waist_surgery::*` modules,
+warm-start API.
+
+### Python
+
+- `TreeSA(..., preprocess=True, surgery_budget=0.0)` — same semantics;
+  `optimize_treesa` picks up the defaults.
+- New functions for manual composition:
+  - `simplify_then_optimize(ixs, out, sizes, optimizer) -> (NestedEinsum,
+    SimplifyReport)`
+  - `waist_refine(tree, ixs, out, sizes, budget_secs) -> (NestedEinsum,
+    WaistReport)`
+- New pyclasses `SimplifyReport` (n_original, n_reduced, shrink) and
+  `WaistReport` (existing counter fields), read-only.
+
+## 2. Rule removal and migration
+
+- **CLAUDE.md**: replace the "MUST stay aligned with Julia" section with:
+  omeco is independent; the JSON format remains Julia-interoperable; check
+  the Julia implementation for reference when porting algorithms, not for
+  behavioral parity. Drop the "do not modify ALIGNED WITH JULIA tests" rule
+  and the "benchmark tc must match Julia" CI requirement text.
+- **Tests**: keep every ALIGNED-WITH-JULIA test as an ordinary regression
+  test. Where `preprocess: true` changes an exact expected tree, update the
+  expectation deliberately (one commit per test file, each reviewed against
+  the new pipeline's contraction_complexity — never blanket-regenerated).
+  Tests asserting tolerance-band tc against recorded Julia values stay
+  as-is if they still pass (preprocess never worsens quality; investigate
+  any that fail rather than relaxing them).
+- **CI**: the Julia-comparison benchmark becomes a non-blocking
+  informational job; it no longer gates merges.
+- **README**: "ported from" -> "originated as a port of"; positioning text
+  updated.
+
+## 3. Documentation
+
+- README quickstart: default path shown first
+  (`optimize_code(ixs, out, sizes, TreeSA())` in Python, three lines), with
+  the surgery flag shown as the "spend more time, get a better tree" knob.
+- mdBook: new page "How omeco optimizes by default" — pipeline diagram
+  (simplify -> anneal -> splice -> optional surgery), when surgery helps
+  (frozen-waist instances; cites the paper), determinism note and the
+  `surgery_budget=0` escape hatch, preprocessing guarantees (exactness, sc
+  never harmed, no tc-optimality claim).
+- rustdoc: examples on both new fields; `# Determinism` note on
+  `surgery_budget`.
+
+## 4. Testing
+
+- Default pipeline quality: on each benchmark graph, `TreeSA::default()`
+  tc <= plain trial-loop tc + 0.5 bits (empirical bound — preprocessing
+  carries no tc-optimality theorem; on graphs where simplify is a no-op,
+  such as reg3, assert exact equality instead).
+- Reproducibility: `surgery_budget = 0.0` + fixed config produces identical
+  trees across two runs.
+- Interface invariants with `preprocess: true`: leaf count preserved,
+  recursive parent/child interfaces consistent (reuse existing helpers).
+- Surgery flag: with a small budget on a frozen-waist-style instance,
+  result tc <= no-surgery tc; report counters populated.
+- Python: round-trip tests for the new bindings and report types; defaults
+  visible from Python match Rust.
+- Coverage stays above the project's 95% bar.
+
+## 5. Versioning and rollout
+
+- Patch bump via `make bump-patch` (maintainer decision 2026-07-29; the
+  default-output change is called out prominently in the changelog instead
+  of a minor bump).
+- Changelog: states the `preprocess: true` default, the unchanged-behavior
+  escape (`TreeSA { preprocess: false, surgery_budget: 0.0, ..cfg }`), and
+  the alignment-rule retirement.
+- Single PR off `master`; the paper repo is unaffected (its pinned data is
+  frozen; nothing in the figure pipeline calls TreeSA).
+
+## Out of scope
+
+- Interleaved anneal/surgery loop as a library optimizer (the warm-start
+  API already enables it for power users; revisit on demand).
+- Composable stage combinators.
+- Changing `GreedyMethod`/`Treewidth` defaults.
+- Dropping Julia JSON interop.

--- a/docs/superpowers/specs/2026-07-29-usability-post-alignment-design.md
+++ b/docs/superpowers/specs/2026-07-29-usability-post-alignment-design.md
@@ -135,3 +135,7 @@ warm-start API.
 - Composable stage combinators.
 - Changing `GreedyMethod`/`Treewidth` defaults.
 - Dropping Julia JSON interop.
+
+## Amendment (2026-07-29): maintainer direction replaced `surgery_budget`
+(seconds) with `surgery_iters: u64` (deterministic iteration cap, default 0 =
+off); wall-clock budgets remain only on the low-level waist_surgery APIs.

--- a/omeco-python/pyproject.toml
+++ b/omeco-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "omeco"
-version = "0.2.6"
+version = "0.2.7"
 description = "Tensor network contraction order optimization"
 readme = "README.md"
 license = { text = "MIT" }

--- a/omeco-python/python/omeco/__init__.py
+++ b/omeco-python/python/omeco/__init__.py
@@ -15,7 +15,7 @@ Classes:
         ExhaustiveSearch(verbose=False)
 
     TreeSA: Simulated annealing optimizer.
-        TreeSA(ntrials=10, niters=50, betas=None, score=None, preprocess=True, surgery_budget=0.0)
+        TreeSA(ntrials=10, niters=50, betas=None, score=None, preprocess=True, surgery_iters=0)
         TreeSA.fast(score=None)
 
     Treewidth: Scalable treewidth-heuristic elimination-order optimizer.

--- a/omeco-python/python/omeco/__init__.py
+++ b/omeco-python/python/omeco/__init__.py
@@ -15,7 +15,7 @@ Classes:
         ExhaustiveSearch(verbose=False)
 
     TreeSA: Simulated annealing optimizer.
-        TreeSA(ntrials=10, niters=50, betas=None, score=None)
+        TreeSA(ntrials=10, niters=50, betas=None, score=None, preprocess=True, surgery_budget=0.0)
         TreeSA.fast(score=None)
 
     Treewidth: Scalable treewidth-heuristic elimination-order optimizer.
@@ -72,6 +72,8 @@ from omeco._core import (
     TreeSA,
     Treewidth,
     TreeSASlicer,
+    SimplifyReport,
+    WaistReport,
     # Functions
     optimize_code,
     optimize_exhaustive,
@@ -80,6 +82,8 @@ from omeco._core import (
     sliced_complexity,
     slice_code,
     uniform_size_dict,
+    simplify_then_optimize,
+    waist_refine,
 )
 
 __version__ = "0.2.6"
@@ -93,6 +97,8 @@ __all__ = [
     "TreeSA",
     "Treewidth",
     "TreeSASlicer",
+    "SimplifyReport",
+    "WaistReport",
     "optimize_code",
     "optimize_exhaustive",
     "optimize_treewidth",
@@ -100,4 +106,6 @@ __all__ = [
     "sliced_complexity",
     "slice_code",
     "uniform_size_dict",
+    "simplify_then_optimize",
+    "waist_refine",
 ]

--- a/omeco-python/python/omeco/__init__.py
+++ b/omeco-python/python/omeco/__init__.py
@@ -86,7 +86,7 @@ from omeco._core import (
     waist_refine,
 )
 
-__version__ = "0.2.6"
+__version__ = "0.2.7"
 __all__ = [
     "NestedEinsum",
     "SlicedEinsum",

--- a/omeco-python/src/lib.rs
+++ b/omeco-python/src/lib.rs
@@ -543,13 +543,19 @@ impl PyTreeSA {
     ///     niters: Iterations per temperature level (default: 50).
     ///     betas: Inverse temperature schedule. If None, uses default schedule.
     ///     score: Score function for evaluating solutions. If None, uses default.
+    ///     preprocess: Simplify the network (splice degree-2/parallel tensors) before
+    ///                 annealing, then splice the reduced tree back (default: True).
+    ///     surgery_budget: Wall-clock seconds for a post-annealing waist-surgery
+    ///                     refinement pass; 0.0 disables it (default: 0.0).
     #[new]
-    #[pyo3(signature = (ntrials=10, niters=50, betas=None, score=None))]
+    #[pyo3(signature = (ntrials=10, niters=50, betas=None, score=None, preprocess=true, surgery_budget=0.0))]
     fn new(
         ntrials: usize,
         niters: usize,
         betas: Option<Vec<f64>>,
         score: Option<PyScoreFunction>,
+        preprocess: bool,
+        surgery_budget: f64,
     ) -> Self {
         let default_betas: Vec<f64> = (1..=300).map(|i| 0.01 + 0.05 * i as f64).collect();
         let betas = betas.unwrap_or(default_betas);
@@ -561,6 +567,8 @@ impl PyTreeSA {
                 ntrials,
                 niters,
                 score,
+                preprocess,
+                surgery_budget,
                 ..Default::default()
             },
         }
@@ -604,6 +612,19 @@ impl PyTreeSA {
         PyScoreFunction {
             inner: self.inner.score.clone(),
         }
+    }
+
+    /// Whether the network is simplified before annealing and spliced back after.
+    #[getter]
+    fn preprocess(&self) -> bool {
+        self.inner.preprocess
+    }
+
+    /// Wall-clock seconds budgeted for the post-annealing waist-surgery pass
+    /// (0.0 disables it).
+    #[getter]
+    fn surgery_budget(&self) -> f64 {
+        self.inner.surgery_budget
     }
 
     fn __repr__(&self) -> String {
@@ -750,6 +771,101 @@ impl PyTreeSASlicer {
     }
 }
 
+/// Statistics describing how far the structural simplification pass shrank a
+/// network, returned alongside the optimized tree by `simplify_then_optimize`.
+#[pyclass(name = "SimplifyReport")]
+#[derive(Clone)]
+pub struct PySimplifyReport {
+    inner: omeco::preprocess::SimplifyReport,
+}
+
+#[pymethods]
+impl PySimplifyReport {
+    /// Number of tensors in the original network.
+    #[getter]
+    fn n_original(&self) -> usize {
+        self.inner.n_original
+    }
+
+    /// Number of super-tensors surviving in the reduced network.
+    #[getter]
+    fn n_reduced(&self) -> usize {
+        self.inner.n_reduced
+    }
+
+    /// Fraction of tensors removed: `1 - n_reduced / n_original` (0 when empty).
+    #[getter]
+    fn shrink(&self) -> f64 {
+        self.inner.shrink
+    }
+
+    fn __repr__(&self) -> String {
+        format!(
+            "SimplifyReport(n_original={}, n_reduced={}, shrink={:.3})",
+            self.inner.n_original, self.inner.n_reduced, self.inner.shrink
+        )
+    }
+}
+
+/// Diagnostics from a `waist_refine` run.
+#[pyclass(name = "WaistReport")]
+#[derive(Clone)]
+pub struct PyWaistReport {
+    inner: omeco::waist_surgery::WaistReport,
+}
+
+#[pymethods]
+impl PyWaistReport {
+    /// Number of tensors in the input network.
+    #[getter]
+    fn n_original(&self) -> usize {
+        self.inner.n_original
+    }
+
+    /// Number of waist-surgery iterations attempted.
+    #[getter]
+    fn surgery_calls(&self) -> u64 {
+        self.inner.surgery_calls
+    }
+
+    /// Iterations where bounded FM strictly improved the incumbent partition
+    /// under the same cut-weight functional.
+    #[getter]
+    fn cheaper_cuts(&self) -> u64 {
+        self.inner.cheaper_cuts
+    }
+
+    /// Candidates that passed the no-new-bottleneck gate and entered rebuilding.
+    #[getter]
+    fn rebuild_attempts(&self) -> u64 {
+        self.inner.rebuild_attempts
+    }
+
+    /// Rebuilds that strictly lowered the global time complexity and were kept.
+    #[getter]
+    fn rebuild_accepts(&self) -> u64 {
+        self.inner.rebuild_accepts
+    }
+
+    /// Iterations where the bounded FM search found no cheaper comparable cut.
+    #[getter]
+    fn waist_min_hits(&self) -> u64 {
+        self.inner.waist_min_hits
+    }
+
+    fn __repr__(&self) -> String {
+        format!(
+            "WaistReport(n_original={}, surgery_calls={}, cheaper_cuts={}, rebuild_attempts={}, rebuild_accepts={}, waist_min_hits={})",
+            self.inner.n_original,
+            self.inner.surgery_calls,
+            self.inner.cheaper_cuts,
+            self.inner.rebuild_attempts,
+            self.inner.rebuild_accepts,
+            self.inner.waist_min_hits
+        )
+    }
+}
+
 /// Optimize the contraction order using greedy method.
 ///
 /// Args:
@@ -796,12 +912,82 @@ fn optimize_treesa(
     optimizer: Option<PyTreeSA>,
 ) -> PyResult<PyNestedEinsum> {
     let code = EinCode::new(ixs, out);
-    let opt = optimizer.unwrap_or_else(|| PyTreeSA::new(10, 50, None, None));
+    let opt = optimizer.unwrap_or_else(|| PyTreeSA::new(10, 50, None, None, true, 0.0));
 
     opt.inner
         .optimize(&code, &sizes)
         .map(|inner| PyNestedEinsum { inner })
         .ok_or_else(|| PyValueError::new_err("Optimization failed"))
+}
+
+/// Simplify a network (splice degree-2/parallel tensors), optimize the reduced
+/// network, then splice the reduced tree back into a full contraction tree.
+///
+/// Only a `GreedyMethod` optimizer is accepted here: the reduced-network
+/// optimizer is generic over `CodeOptimizer` on the Rust side, which cannot
+/// cross the PyO3 boundary, so Greedy is the documented inner optimizer for
+/// this pipeline. TreeSA users get the same simplify/splice behavior via
+/// `TreeSA(preprocess=True)` (the default) instead of calling this function
+/// directly.
+///
+/// Args:
+///     ixs: List of index lists for each tensor.
+///     out: Output indices.
+///     sizes: Dictionary mapping indices to their dimensions.
+///     optimizer: GreedyMethod optimizer for the reduced network (default: GreedyMethod()).
+///
+/// Returns:
+///     A tuple of (optimized contraction tree, SimplifyReport).
+#[pyfunction]
+#[pyo3(signature = (ixs, out, sizes, optimizer=None))]
+fn simplify_then_optimize(
+    ixs: Vec<Vec<i64>>,
+    out: Vec<i64>,
+    sizes: HashMap<i64, usize>,
+    optimizer: Option<PyGreedyMethod>,
+) -> PyResult<(PyNestedEinsum, PySimplifyReport)> {
+    let code = EinCode::new(ixs, out);
+    let opt = optimizer.map(|o| o.inner).unwrap_or_default();
+    omeco::preprocess::simplify_then_optimize(&code, &sizes, &opt)
+        .map(|(t, r)| (PyNestedEinsum { inner: t }, PySimplifyReport { inner: r }))
+        .ok_or_else(|| PyValueError::new_err("optimization failed"))
+}
+
+/// Refine a contraction tree with a bounded waist-surgery pass: repeatedly
+/// finds and repairs the tree's costliest cut, keeping only rebuilds that
+/// strictly lower the global time complexity, within a wall-clock budget.
+///
+/// Args:
+///     tree: Seed contraction tree to refine (e.g. from `optimize_code`).
+///     ixs: List of index lists for each tensor.
+///     out: Output indices.
+///     sizes: Dictionary mapping indices to their dimensions.
+///     budget_secs: Wall-clock seconds to spend surgering; must be finite and >= 0.
+///
+/// Returns:
+///     A tuple of (refined contraction tree, WaistReport). The refined tree's
+///     time complexity is never worse than the input tree's.
+#[pyfunction]
+fn waist_refine(
+    tree: PyNestedEinsum,
+    ixs: Vec<Vec<i64>>,
+    out: Vec<i64>,
+    sizes: HashMap<i64, usize>,
+    budget_secs: f64,
+) -> PyResult<(PyNestedEinsum, PyWaistReport)> {
+    if !budget_secs.is_finite() || budget_secs < 0.0 {
+        return Err(PyValueError::new_err(
+            "budget_secs must be a non-negative finite number",
+        ));
+    }
+    let code = EinCode::new(ixs, out);
+    let (t, r) = omeco::waist_surgery::refine(
+        &tree.inner,
+        &code,
+        &sizes,
+        std::time::Duration::from_secs_f64(budget_secs),
+    );
+    Ok((PyNestedEinsum { inner: t }, PyWaistReport { inner: r }))
 }
 
 /// Optimize the contraction order using the treewidth heuristic.
@@ -1079,11 +1265,15 @@ fn _core(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PyTreeSA>()?;
     m.add_class::<PyTreewidth>()?;
     m.add_class::<PyTreeSASlicer>()?;
+    m.add_class::<PySimplifyReport>()?;
+    m.add_class::<PyWaistReport>()?;
     m.add_function(wrap_pyfunction!(optimize_code, m)?)?;
     m.add_function(wrap_pyfunction!(optimize_greedy, m)?)?;
     m.add_function(wrap_pyfunction!(optimize_exhaustive, m)?)?;
     m.add_function(wrap_pyfunction!(optimize_treesa, m)?)?;
     m.add_function(wrap_pyfunction!(optimize_treewidth, m)?)?;
+    m.add_function(wrap_pyfunction!(simplify_then_optimize, m)?)?;
+    m.add_function(wrap_pyfunction!(waist_refine, m)?)?;
     m.add_function(wrap_pyfunction!(contraction_complexity, m)?)?;
     m.add_function(wrap_pyfunction!(sliced_complexity, m)?)?;
     m.add_function(wrap_pyfunction!(uniform_size_dict, m)?)?;

--- a/omeco-python/src/lib.rs
+++ b/omeco-python/src/lib.rs
@@ -545,17 +545,18 @@ impl PyTreeSA {
     ///     score: Score function for evaluating solutions. If None, uses default.
     ///     preprocess: Simplify the network (splice degree-2/parallel tensors) before
     ///                 annealing, then splice the reduced tree back (default: True).
-    ///     surgery_budget: Wall-clock seconds for a post-annealing waist-surgery
-    ///                     refinement pass; 0.0 disables it (default: 0.0).
+    ///     surgery_iters: Deterministic cap on post-annealing waist-surgery
+    ///                    iterations; 0 disables it (default: 0). Fully
+    ///                    reproducible across machines for any fixed config.
     #[new]
-    #[pyo3(signature = (ntrials=10, niters=50, betas=None, score=None, preprocess=true, surgery_budget=0.0))]
+    #[pyo3(signature = (ntrials=10, niters=50, betas=None, score=None, preprocess=true, surgery_iters=0))]
     fn new(
         ntrials: usize,
         niters: usize,
         betas: Option<Vec<f64>>,
         score: Option<PyScoreFunction>,
         preprocess: bool,
-        surgery_budget: f64,
+        surgery_iters: u64,
     ) -> Self {
         let default_betas: Vec<f64> = (1..=300).map(|i| 0.01 + 0.05 * i as f64).collect();
         let betas = betas.unwrap_or(default_betas);
@@ -568,7 +569,7 @@ impl PyTreeSA {
                 niters,
                 score,
                 preprocess,
-                surgery_budget,
+                surgery_iters,
                 ..Default::default()
             },
         }
@@ -620,16 +621,16 @@ impl PyTreeSA {
         self.inner.preprocess
     }
 
-    /// Wall-clock seconds budgeted for the post-annealing waist-surgery pass
-    /// (0.0 disables it).
+    /// Deterministic cap on post-annealing waist-surgery iterations (0
+    /// disables it).
     #[getter]
-    fn surgery_budget(&self) -> f64 {
-        self.inner.surgery_budget
+    fn surgery_iters(&self) -> u64 {
+        self.inner.surgery_iters
     }
 
     fn __repr__(&self) -> String {
         format!(
-            "TreeSA(ntrials={}, niters={}, score={}, preprocess={}, surgery_budget={})",
+            "TreeSA(ntrials={}, niters={}, score={}, preprocess={}, surgery_iters={})",
             self.inner.ntrials,
             self.inner.niters,
             PyScoreFunction {
@@ -641,7 +642,7 @@ impl PyTreeSA {
             } else {
                 "False"
             },
-            self.inner.surgery_budget,
+            self.inner.surgery_iters,
         )
     }
 }
@@ -918,7 +919,7 @@ fn optimize_treesa(
     optimizer: Option<PyTreeSA>,
 ) -> PyResult<PyNestedEinsum> {
     let code = EinCode::new(ixs, out);
-    let opt = optimizer.unwrap_or_else(|| PyTreeSA::new(10, 50, None, None, true, 0.0));
+    let opt = optimizer.unwrap_or_else(|| PyTreeSA::new(10, 50, None, None, true, 0));
 
     opt.inner
         .optimize(&code, &sizes)
@@ -969,17 +970,22 @@ fn simplify_then_optimize(
 ///     out: Output indices.
 ///     sizes: Dictionary mapping indices to their dimensions.
 ///     budget_secs: Wall-clock seconds to spend surgering; must be finite and >= 0.
+///     max_iters: Deterministic cap on the number of surgery iterations
+///                started; 0 (default) is uncapped, bounded only by
+///                `budget_secs`.
 ///
 /// Returns:
 ///     A tuple of (refined contraction tree, WaistReport). The refined tree's
 ///     time complexity is never worse than the input tree's.
 #[pyfunction]
+#[pyo3(signature = (tree, ixs, out, sizes, budget_secs, max_iters=0))]
 fn waist_refine(
     tree: PyNestedEinsum,
     ixs: Vec<Vec<i64>>,
     out: Vec<i64>,
     sizes: HashMap<i64, usize>,
     budget_secs: f64,
+    max_iters: u64,
 ) -> PyResult<(PyNestedEinsum, PyWaistReport)> {
     if !budget_secs.is_finite() || budget_secs < 0.0 {
         return Err(PyValueError::new_err(
@@ -987,11 +993,12 @@ fn waist_refine(
         ));
     }
     let code = EinCode::new(ixs, out);
-    let (t, r) = omeco::waist_surgery::refine(
+    let (t, r) = omeco::waist_surgery::refine_capped(
         &tree.inner,
         &code,
         &sizes,
         std::time::Duration::from_secs_f64(budget_secs),
+        max_iters,
     );
     Ok((PyNestedEinsum { inner: t }, PyWaistReport { inner: r }))
 }

--- a/omeco-python/src/lib.rs
+++ b/omeco-python/src/lib.rs
@@ -629,13 +629,19 @@ impl PyTreeSA {
 
     fn __repr__(&self) -> String {
         format!(
-            "TreeSA(ntrials={}, niters={}, score={})",
+            "TreeSA(ntrials={}, niters={}, score={}, preprocess={}, surgery_budget={})",
             self.inner.ntrials,
             self.inner.niters,
             PyScoreFunction {
                 inner: self.inner.score.clone()
             }
-            .__repr__()
+            .__repr__(),
+            if self.inner.preprocess {
+                "True"
+            } else {
+                "False"
+            },
+            self.inner.surgery_budget,
         )
     }
 }

--- a/omeco-python/tests/test_omeco.py
+++ b/omeco-python/tests/test_omeco.py
@@ -472,14 +472,20 @@ def test_treesa_getters():
 
 
 def test_treesa_repr():
-    """__repr__ must surface preprocess and surgery_budget, not just ntrials/niters/score."""
-    opt = TreeSA(ntrials=3, niters=15, preprocess=False, surgery_budget=1.5)
+    """__repr__ must surface preprocess and surgery_iters, not just ntrials/niters/score."""
+    opt = TreeSA(ntrials=3, niters=15, preprocess=False, surgery_iters=7)
     repr_str = repr(opt)
     assert "TreeSA" in repr_str
     assert "ntrials=3" in repr_str
     assert "niters=15" in repr_str
     assert "preprocess=False" in repr_str
-    assert "surgery_budget=1.5" in repr_str
+    assert "surgery_iters=7" in repr_str
+
+
+def test_treesa_surgery_iters_getter_and_default():
+    """surgery_iters defaults to 0 and round-trips through the constructor."""
+    assert TreeSA().surgery_iters == 0
+    assert TreeSA(surgery_iters=7).surgery_iters == 7
 
 
 # ============== New tests for TreeSASlicer constructor ==============

--- a/omeco-python/tests/test_omeco.py
+++ b/omeco-python/tests/test_omeco.py
@@ -471,6 +471,17 @@ def test_treesa_getters():
     assert len(opt.betas) > 0
 
 
+def test_treesa_repr():
+    """__repr__ must surface preprocess and surgery_budget, not just ntrials/niters/score."""
+    opt = TreeSA(ntrials=3, niters=15, preprocess=False, surgery_budget=1.5)
+    repr_str = repr(opt)
+    assert "TreeSA" in repr_str
+    assert "ntrials=3" in repr_str
+    assert "niters=15" in repr_str
+    assert "preprocess=False" in repr_str
+    assert "surgery_budget=1.5" in repr_str
+
+
 # ============== New tests for TreeSASlicer constructor ==============
 
 

--- a/omeco-python/tests/test_pipeline.py
+++ b/omeco-python/tests/test_pipeline.py
@@ -1,0 +1,38 @@
+from omeco import (
+    TreeSA, GreedyMethod, optimize_code, contraction_complexity,
+    simplify_then_optimize, waist_refine,
+)
+
+CHAIN_IXS = [[0, 1], [1, 2], [2, 3], [3, 4]]
+CHAIN_OUT = [0, 4]
+CHAIN_SIZES = {i: 2 for i in range(5)}
+
+
+def test_treesa_pipeline_defaults():
+    opt = TreeSA()
+    assert opt.preprocess is True
+    assert opt.surgery_budget == 0.0
+    opt2 = TreeSA(preprocess=False, surgery_budget=1.5)
+    assert opt2.preprocess is False
+    assert opt2.surgery_budget == 1.5
+
+
+def test_treesa_default_keeps_all_leaves():
+    tree = optimize_code(CHAIN_IXS, CHAIN_OUT, CHAIN_SIZES, TreeSA(ntrials=1, niters=5))
+    assert tree.leaf_count() == 4
+
+
+def test_simplify_then_optimize_reports_shrink():
+    tree, report = simplify_then_optimize(CHAIN_IXS, CHAIN_OUT, CHAIN_SIZES, GreedyMethod())
+    assert tree.leaf_count() == 4
+    assert report.n_original == 4
+    assert report.n_reduced <= report.n_original
+
+
+def test_waist_refine_never_worse():
+    seed = optimize_code(CHAIN_IXS, CHAIN_OUT, CHAIN_SIZES, GreedyMethod())
+    seed_tc = contraction_complexity(seed, CHAIN_IXS, CHAIN_SIZES).tc
+    refined, report = waist_refine(seed, CHAIN_IXS, CHAIN_OUT, CHAIN_SIZES, 0.5)
+    tc = contraction_complexity(refined, CHAIN_IXS, CHAIN_SIZES).tc
+    assert tc <= seed_tc + 1e-9
+    assert report.surgery_calls >= 0

--- a/omeco-python/tests/test_pipeline.py
+++ b/omeco-python/tests/test_pipeline.py
@@ -11,10 +11,10 @@ CHAIN_SIZES = {i: 2 for i in range(5)}
 def test_treesa_pipeline_defaults():
     opt = TreeSA()
     assert opt.preprocess is True
-    assert opt.surgery_budget == 0.0
-    opt2 = TreeSA(preprocess=False, surgery_budget=1.5)
+    assert opt.surgery_iters == 0
+    opt2 = TreeSA(preprocess=False, surgery_iters=7)
     assert opt2.preprocess is False
-    assert opt2.surgery_budget == 1.5
+    assert opt2.surgery_iters == 7
 
 
 def test_treesa_default_keeps_all_leaves():
@@ -36,3 +36,14 @@ def test_waist_refine_never_worse():
     tc = contraction_complexity(refined, CHAIN_IXS, CHAIN_SIZES).tc
     assert tc <= seed_tc + 1e-9
     assert report.surgery_calls >= 0
+
+
+def test_waist_refine_max_iters_caps_surgery_calls():
+    seed = optimize_code(CHAIN_IXS, CHAIN_OUT, CHAIN_SIZES, GreedyMethod())
+    refined, report = waist_refine(
+        seed, CHAIN_IXS, CHAIN_OUT, CHAIN_SIZES, 3600.0, max_iters=2
+    )
+    assert report.surgery_calls <= 2
+    tc = contraction_complexity(refined, CHAIN_IXS, CHAIN_SIZES).tc
+    seed_tc = contraction_complexity(seed, CHAIN_IXS, CHAIN_SIZES).tc
+    assert tc <= seed_tc + 1e-9

--- a/omeco/Cargo.toml
+++ b/omeco/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "omeco"
-version = "0.2.6"
+version = "0.2.7"
 edition = "2021"
 description = "Tensor network contraction order optimization"
 license = "MIT"

--- a/omeco/src/eincode.rs
+++ b/omeco/src/eincode.rs
@@ -918,6 +918,8 @@ mod tests {
             initializer: Initializer::Greedy,
             decomposition_type: DecompositionType::Path,
             score: Default::default(),
+            preprocess: false,
+            surgery_budget: 0.0,
         };
         let treesa_result = optimize_treesa(&code, &sizes, &treesa_config).unwrap();
 

--- a/omeco/src/eincode.rs
+++ b/omeco/src/eincode.rs
@@ -919,7 +919,7 @@ mod tests {
             decomposition_type: DecompositionType::Path,
             score: Default::default(),
             preprocess: false,
-            surgery_budget: 0.0,
+            surgery_iters: 0,
         };
         let treesa_result = optimize_treesa(&code, &sizes, &treesa_config).unwrap();
 

--- a/omeco/src/label.rs
+++ b/omeco/src/label.rs
@@ -11,6 +11,9 @@ use std::hash::Hash;
 /// Labels are used to identify tensor dimensions in einsum notation.
 /// Common choices are `char` (e.g., `'i'`, `'j'`) or `usize` for programmatic use.
 ///
+/// Requires `Ord` for deterministic preprocessing operations that rely on
+/// consistent ordering of labels.
+///
 /// # Example
 /// ```
 /// use omeco::Label;
@@ -19,7 +22,7 @@ use std::hash::Hash;
 ///     // Works with any label type
 /// }
 /// ```
-pub trait Label: Clone + Eq + Hash + Debug + Send + Sync + 'static {}
+pub trait Label: Clone + Eq + Ord + Hash + Debug + Send + Sync + 'static {}
 
 // Implement Label for common types
 impl Label for char {}

--- a/omeco/src/lib.rs
+++ b/omeco/src/lib.rs
@@ -1097,9 +1097,30 @@ mod large_scale_stress_tests {
         let graph = generate_random_regular_graph(50, 3, 789);
         let (code, sizes) = graph_to_eincode(&graph);
 
+        // Deviation from task-3-brief.md Step 4 (2026-07-29
+        // usability-post-alignment): TreeSA's preprocessing front-end is now on
+        // by default. `graph_to_eincode` always adds a rank-1 tensor per vertex,
+        // and every one of those is unconditionally absorbed into a neighbouring
+        // edge tensor by `simplify` (rank-non-increasing, same uniform size) —
+        // confirmed empirically: 125 tensors -> 75, and re-running `simplify` on
+        // the 75-tensor result is a no-op (a genuine fixed point). Splicing a
+        // 2-leaf merge back into a leaf slot of the path-shaped reduced tree can
+        // give that slot's parent two non-leaf children, which breaks the strict
+        // `is_path_decomposition` check on the full *spliced* tree even though
+        // the trial loop itself still produced a path order over the reduced
+        // network. `DecompositionType::Path` is a property of that trial loop,
+        // so exercise it on the already-fully-reduced (fixed-point) network
+        // instead of disabling `TreeSA::preprocess`.
+        let simplified = simplify(&code, &sizes);
+        debug_assert_eq!(
+            simplify(&simplified.code, &sizes).report.n_reduced,
+            simplified.report.n_reduced,
+            "reduced network must be a simplify fixed point for this test to be meaningful"
+        );
+
         // Optimize with path decomposition
         let path_treesa = TreeSA::path().with_niters(30).with_ntrials(2);
-        let path_tree = optimize_code(&code, &sizes, &path_treesa);
+        let path_tree = optimize_code(&simplified.code, &sizes, &path_treesa);
         assert!(path_tree.is_some(), "Path TreeSA should succeed");
 
         let tree = path_tree.unwrap();
@@ -1112,7 +1133,7 @@ mod large_scale_stress_tests {
 
         // Also verify with tree decomposition for comparison
         let tree_treesa = TreeSA::default().with_niters(30).with_ntrials(2);
-        let tree_tree = optimize_code(&code, &sizes, &tree_treesa);
+        let tree_tree = optimize_code(&simplified.code, &sizes, &tree_treesa);
         assert!(tree_tree.is_some());
 
         // Tree decomposition typically doesn't produce path structure

--- a/omeco/src/lib.rs
+++ b/omeco/src/lib.rs
@@ -1097,30 +1097,9 @@ mod large_scale_stress_tests {
         let graph = generate_random_regular_graph(50, 3, 789);
         let (code, sizes) = graph_to_eincode(&graph);
 
-        // Deviation from task-3-brief.md Step 4 (2026-07-29
-        // usability-post-alignment): TreeSA's preprocessing front-end is now on
-        // by default. `graph_to_eincode` always adds a rank-1 tensor per vertex,
-        // and every one of those is unconditionally absorbed into a neighbouring
-        // edge tensor by `simplify` (rank-non-increasing, same uniform size) —
-        // confirmed empirically: 125 tensors -> 75, and re-running `simplify` on
-        // the 75-tensor result is a no-op (a genuine fixed point). Splicing a
-        // 2-leaf merge back into a leaf slot of the path-shaped reduced tree can
-        // give that slot's parent two non-leaf children, which breaks the strict
-        // `is_path_decomposition` check on the full *spliced* tree even though
-        // the trial loop itself still produced a path order over the reduced
-        // network. `DecompositionType::Path` is a property of that trial loop,
-        // so exercise it on the already-fully-reduced (fixed-point) network
-        // instead of disabling `TreeSA::preprocess`.
-        let simplified = simplify(&code, &sizes);
-        debug_assert_eq!(
-            simplify(&simplified.code, &sizes).report.n_reduced,
-            simplified.report.n_reduced,
-            "reduced network must be a simplify fixed point for this test to be meaningful"
-        );
-
         // Optimize with path decomposition
         let path_treesa = TreeSA::path().with_niters(30).with_ntrials(2);
-        let path_tree = optimize_code(&simplified.code, &sizes, &path_treesa);
+        let path_tree = optimize_code(&code, &sizes, &path_treesa);
         assert!(path_tree.is_some(), "Path TreeSA should succeed");
 
         let tree = path_tree.unwrap();
@@ -1133,7 +1112,7 @@ mod large_scale_stress_tests {
 
         // Also verify with tree decomposition for comparison
         let tree_treesa = TreeSA::default().with_niters(30).with_ntrials(2);
-        let tree_tree = optimize_code(&simplified.code, &sizes, &tree_treesa);
+        let tree_tree = optimize_code(&code, &sizes, &tree_treesa);
         assert!(tree_tree.is_some());
 
         // Tree decomposition typically doesn't produce path structure

--- a/omeco/src/lib.rs
+++ b/omeco/src/lib.rs
@@ -1295,7 +1295,7 @@ mod large_scale_stress_tests {
     #[test]
     fn test_reg3_220_treesa() {
         // =========================================================================
-        // ALIGNED WITH JULIA - DO NOT MODIFY WITHOUT CHECKING JULIA TESTS
+        // REGRESSION (originally cross-checked against Julia test/treesa.jl)
         // Julia "sa tree" test in test/treesa.jl:
         //   Random.seed!(2)
         //   code = random_regular_eincode(220, 3)

--- a/omeco/src/preprocess.rs
+++ b/omeco/src/preprocess.rs
@@ -115,8 +115,8 @@ pub struct Simplified<L: Label> {
 /// a surviving tensor whose rank and dimension-aware storage are no larger than
 /// the respective maximum of the inputs. Missing dimensions are treated as one,
 /// consistently with the other optimizers. The pass is deterministic (labels,
-/// neighbours, and requeued tensors are processed in sorted order) and requires
-/// `L: Ord` for that determinism.
+/// neighbours, and requeued tensors are processed in sorted order); `Ord` is
+/// provided by the `Label` trait.
 ///
 /// # Example
 ///
@@ -133,7 +133,7 @@ pub struct Simplified<L: Label> {
 /// assert_eq!(simplified.report.n_original, 2);
 /// assert_eq!(simplified.report.n_reduced, 1);
 /// ```
-pub fn simplify<L: Label + Ord>(code: &EinCode<L>, size_dict: &HashMap<L, usize>) -> Simplified<L> {
+pub fn simplify<L: Label>(code: &EinCode<L>, size_dict: &HashMap<L, usize>) -> Simplified<L> {
     let n = code.ixs.len();
     let out_set: HashSet<L> = code.iy.iter().cloned().collect();
 
@@ -383,7 +383,7 @@ pub fn splice<L: Label>(tree: &NestedEinsum<L>, subtrees: &[NestedEinsum<L>]) ->
 /// assert!(cc.tc.is_finite());
 /// assert_eq!(report.n_original, 3);
 /// ```
-pub fn simplify_then_optimize<L: Label + Ord, O: CodeOptimizer>(
+pub fn simplify_then_optimize<L: Label, O: CodeOptimizer>(
     code: &EinCode<L>,
     size_dict: &HashMap<L, usize>,
     optimizer: &O,

--- a/omeco/src/treesa.rs
+++ b/omeco/src/treesa.rs
@@ -690,7 +690,10 @@ fn get_child_labels<L: Label>(nested: &NestedEinsum<L>, original_ixs: &[Vec<L>])
 ///
 /// By default this runs the full pipeline: structural simplification
 /// ([`crate::preprocess::simplify`]), the annealing trial loop on the reduced
-/// network, and splice-back — controlled by [`TreeSA::preprocess`].
+/// network, and splice-back — controlled by [`TreeSA::preprocess`]. A
+/// positive [`TreeSA::surgery_budget`] additionally refines the result with
+/// [`crate::waist_surgery::refine`] (never worse; wall-clock dependent, so
+/// results with surgery enabled are not reproducible across machines).
 pub fn optimize_treesa<L: Label>(
     code: &EinCode<L>,
     size_dict: &HashMap<L, usize>,
@@ -703,6 +706,13 @@ pub fn optimize_treesa<L: Label>(
     } else {
         optimize_treesa_core(code, size_dict, config)?
     };
+
+    if config.surgery_budget > 0.0 {
+        let budget = std::time::Duration::from_secs_f64(config.surgery_budget);
+        let (refined, _report) = crate::waist_surgery::refine(&tree, code, size_dict, budget);
+        return Some(refined);
+    }
+
     Some(tree)
 }
 
@@ -1915,5 +1925,66 @@ mod tests {
             format!("{via_core:?}"),
             "preprocess=false must be byte-identical to the bare trial loop"
         );
+    }
+
+    /// Build a 2D periodic grid tensor network (each bond a distinct label),
+    /// mirroring `waist_surgery`'s own `grid` test helper.
+    fn grid_code(rows: usize, cols: usize) -> EinCode<usize> {
+        let mut next = 0usize;
+        let mut edge = |_a: (usize, usize), _b: (usize, usize)| {
+            let e = next;
+            next += 1;
+            e
+        };
+        // Assign an id per undirected grid edge.
+        let mut hbond = vec![vec![0usize; cols]; rows];
+        let mut vbond = vec![vec![0usize; cols]; rows];
+        for r in 0..rows {
+            for c in 0..cols {
+                hbond[r][c] = edge((r, c), (r, (c + 1) % cols));
+                vbond[r][c] = edge((r, c), ((r + 1) % rows, c));
+            }
+        }
+        let mut ixs = Vec::new();
+        for r in 0..rows {
+            for c in 0..cols {
+                let left = hbond[r][(c + cols - 1) % cols];
+                let right = hbond[r][c];
+                let up = vbond[(r + rows - 1) % rows][c];
+                let down = vbond[r][c];
+                ixs.push(vec![left, right, up, down]);
+            }
+        }
+        EinCode::new(ixs, vec![])
+    }
+
+    #[test]
+    fn test_surgery_budget_never_worse() {
+        use crate::contraction_complexity;
+        // 4x4 periodic grid — a frozen-waist-style instance where surgery acts.
+        let code = grid_code(4, 4);
+        let sizes: HashMap<usize, usize> =
+            code.unique_labels().into_iter().map(|l| (l, 2)).collect();
+        let base_cfg = TreeSA::fast();
+        let base = optimize_treesa(&code, &sizes, &base_cfg).unwrap();
+        let base_tc = contraction_complexity(&base, &sizes, &code.ixs).tc;
+        let cfg = TreeSA::fast().with_surgery_budget(2.0);
+        let refined = optimize_treesa(&code, &sizes, &cfg).unwrap();
+        let refined_tc = contraction_complexity(&refined, &sizes, &code.ixs).tc;
+        assert!(refined_tc <= base_tc + 1e-9, "{refined_tc} > {base_tc}");
+        assert_eq!(refined.leaf_count(), code.num_tensors());
+    }
+
+    #[test]
+    fn test_surgery_off_is_reproducible() {
+        let code = EinCode::new(
+            vec![vec![0usize, 1], vec![1, 2], vec![2, 3], vec![3, 0]],
+            vec![],
+        );
+        let sizes: HashMap<usize, usize> = (0..4).map(|l| (l, 8)).collect();
+        let cfg = TreeSA::fast(); // surgery_budget == 0.0
+        let a = optimize_treesa(&code, &sizes, &cfg).unwrap();
+        let b = optimize_treesa(&code, &sizes, &cfg).unwrap();
+        assert_eq!(format!("{a:?}"), format!("{b:?}"));
     }
 }

--- a/omeco/src/treesa.rs
+++ b/omeco/src/treesa.rs
@@ -10,6 +10,7 @@ use crate::greedy::{optimize_greedy, GreedyMethod};
 use crate::preprocess::{simplify, splice};
 use crate::score::ScoreFunction;
 use crate::utils::fast_log2sumexp2;
+use crate::waist_surgery::refine_capped;
 use crate::Label;
 use rand::prelude::*;
 use rayon::prelude::*;
@@ -765,13 +766,9 @@ pub fn optimize_treesa<L: Label>(
     };
 
     if config.surgery_iters > 0 {
-        let (refined, _report) = crate::waist_surgery::refine_capped(
-            &tree,
-            code,
-            size_dict,
-            std::time::Duration::MAX,
-            config.surgery_iters,
-        );
+        let budget = std::time::Duration::MAX;
+        let (refined, _report) =
+            refine_capped(&tree, code, size_dict, budget, config.surgery_iters);
         return Some(refined);
     }
 
@@ -2085,5 +2082,24 @@ mod tests {
         let tree = optimize_treesa(&code, &sizes, &config).unwrap();
         assert!(tree.is_path_decomposition());
         assert_eq!(tree.leaf_count(), 4);
+    }
+
+    #[test]
+    fn test_random_initializer_produces_valid_tree() {
+        let code = EinCode::new(
+            vec![vec!['a', 'b'], vec!['b', 'c'], vec!['c', 'd']],
+            vec!['a', 'd'],
+        );
+        let sizes: HashMap<char, usize> = [('a', 2), ('b', 2), ('c', 2), ('d', 2)].into();
+        let config = TreeSA {
+            initializer: Initializer::Random,
+            ntrials: 1,
+            niters: 5,
+            ..TreeSA::fast()
+        };
+        let tree = optimize_treesa(&code, &sizes, &config).unwrap();
+        assert_eq!(tree.leaf_count(), 3);
+        let cc = crate::contraction_complexity(&tree, &sizes, &code.ixs);
+        assert!(cc.tc.is_finite());
     }
 }

--- a/omeco/src/treesa.rs
+++ b/omeco/src/treesa.rs
@@ -101,10 +101,19 @@ impl TreeSA {
     }
 
     /// Create a path decomposition variant (linear contraction order).
+    ///
+    /// Sets `preprocess: false`: [`crate::preprocess::splice`] is
+    /// decomposition-agnostic — it substitutes each reduced-network leaf with
+    /// whatever binary subtree `simplify` merged for it, which is not
+    /// path-shaped in general. Running the front-end here can give the
+    /// spliced tree a node with two non-leaf children, breaking this preset's
+    /// documented "linear contraction order" guarantee
+    /// (see [`NestedEinsum::is_path_decomposition`]).
     pub fn path() -> Self {
         Self {
             initializer: Initializer::Random,
             decomposition_type: DecompositionType::Path,
+            preprocess: false,
             ..Default::default()
         }
     }
@@ -681,9 +690,7 @@ fn get_child_labels<L: Label>(nested: &NestedEinsum<L>, original_ixs: &[Vec<L>])
 ///
 /// By default this runs the full pipeline: structural simplification
 /// ([`crate::preprocess::simplify`]), the annealing trial loop on the reduced
-/// network, and splice-back — controlled by [`TreeSA::preprocess`]. A positive
-/// [`TreeSA::surgery_budget`] additionally refines the result with
-/// [`crate::waist_surgery::refine`].
+/// network, and splice-back — controlled by [`TreeSA::preprocess`].
 pub fn optimize_treesa<L: Label>(
     code: &EinCode<L>,
     size_dict: &HashMap<L, usize>,
@@ -1791,6 +1798,19 @@ mod tests {
             .with_surgery_budget(30.0);
         assert!(!tuned.preprocess);
         assert_eq!(tuned.surgery_budget, 30.0);
+    }
+
+    /// Pins the preset-level preprocess contract: `TreeSA::default()` (and
+    /// hence `TreeSA::fast()`, which builds on it) opts into the
+    /// simplify/splice front-end, while `TreeSA::path()` opts out because
+    /// splice does not preserve the path-decomposition guarantee (see the
+    /// doc comment on `TreeSA::path`, and
+    /// `test_path_decomposition_random_graph_n50` in `lib.rs` for the
+    /// end-to-end regression coverage).
+    #[test]
+    fn test_preprocess_default_wiring_per_preset() {
+        assert!(TreeSA::default().preprocess);
+        assert!(!TreeSA::path().preprocess);
     }
 
     #[test]

--- a/omeco/src/treesa.rs
+++ b/omeco/src/treesa.rs
@@ -39,20 +39,23 @@ pub struct TreeSA {
     /// this field is set to `true`: splice does not preserve the
     /// path-decomposition guarantee. See [`TreeSA::path`].
     pub preprocess: bool,
-    /// Wall-clock budget in seconds for the waist-surgery post-pass on the
-    /// selected tree; `0.0` disables it. With a positive budget the result is
-    /// never worse than without, but is not reproducible across machines.
-    /// `f64::INFINITY` (or any value too large to represent as a
-    /// [`std::time::Duration`]) is treated as an effectively unlimited
-    /// budget rather than causing a panic.
-    /// See [`crate::waist_surgery`].
+    /// Deterministic cap on the number of waist-surgery iterations run as a
+    /// post-pass on the selected tree; `0` disables surgery entirely (the
+    /// default). A positive value runs at most that many surgery iterations
+    /// after the pipeline: the result is never worse than with surgery off,
+    /// and more iterations can only be equal or better. See
+    /// [`crate::waist_surgery`].
     ///
     /// # Determinism
     ///
-    /// The surgery pass's RNG seed is fixed, but how much work fits inside
-    /// the budget depends on wall-clock speed, so results with a positive
-    /// budget are **not** reproducible across machines or loads.
-    pub surgery_budget: f64,
+    /// Unlike the low-level [`crate::waist_surgery::refine`]/[`refine_capped`]
+    /// wall-clock APIs, `optimize_treesa` binds surgery to no deadline —
+    /// internal RNG seeds are fixed throughout. The whole `TreeSA` API is
+    /// therefore fully reproducible across machines for any fixed config,
+    /// including configs with `surgery_iters > 0`.
+    ///
+    /// [`refine_capped`]: crate::waist_surgery::refine_capped
+    pub surgery_iters: u64,
 }
 
 /// Method for initializing the contraction tree.
@@ -77,7 +80,7 @@ impl Default for TreeSA {
             score: ScoreFunction::default(),
             decomposition_type: DecompositionType::Tree,
             preprocess: true,
-            surgery_budget: 0.0,
+            surgery_iters: 0,
         }
     }
 }
@@ -99,7 +102,7 @@ impl TreeSA {
             score,
             decomposition_type: DecompositionType::Tree,
             preprocess: true,
-            surgery_budget: 0.0,
+            surgery_iters: 0,
         }
     }
 
@@ -178,7 +181,7 @@ impl TreeSA {
         self
     }
 
-    /// Set the waist-surgery wall-clock budget in seconds (0.0 disables).
+    /// Set the deterministic waist-surgery iteration cap (0 disables).
     ///
     /// # Example
     ///
@@ -191,12 +194,12 @@ impl TreeSA {
     ///     vec!['i', 'l'],
     /// );
     /// let sizes: HashMap<char, usize> = [('i', 2), ('j', 2), ('k', 2), ('l', 2)].into();
-    /// let config = TreeSA::fast().with_surgery_budget(0.1);
+    /// let config = TreeSA::fast().with_surgery_iters(5);
     /// let tree = optimize_treesa(&code, &sizes, &config).unwrap();
     /// assert_eq!(tree.leaf_count(), 3);
     /// ```
-    pub fn with_surgery_budget(mut self, seconds: f64) -> Self {
-        self.surgery_budget = seconds;
+    pub fn with_surgery_iters(mut self, max_iters: u64) -> Self {
+        self.surgery_iters = max_iters;
         self
     }
 }
@@ -737,9 +740,10 @@ fn get_child_labels<L: Label>(nested: &NestedEinsum<L>, original_ixs: &[Vec<L>])
 /// By default this runs the full pipeline: structural simplification
 /// ([`crate::preprocess::simplify`]), the annealing trial loop on the reduced
 /// network, and splice-back — controlled by [`TreeSA::preprocess`]. A
-/// positive [`TreeSA::surgery_budget`] additionally refines the result with
-/// [`crate::waist_surgery::refine`] (never worse; wall-clock dependent, so
-/// results with surgery enabled are not reproducible across machines).
+/// positive [`TreeSA::surgery_iters`] additionally refines the result with
+/// [`crate::waist_surgery::refine_capped`] (never worse than surgery off;
+/// more iterations are equal or better; fully deterministic, since the cap
+/// binds iteration count rather than wall-clock time).
 ///
 /// [`TreeSA::preprocess`] is automatically treated as disabled whenever
 /// [`TreeSA::decomposition_type`] is [`DecompositionType::Path`], even if the
@@ -760,10 +764,14 @@ pub fn optimize_treesa<L: Label>(
         optimize_treesa_core(code, size_dict, config)?
     };
 
-    if config.surgery_budget > 0.0 {
-        let budget = std::time::Duration::try_from_secs_f64(config.surgery_budget)
-            .unwrap_or(std::time::Duration::MAX);
-        let (refined, _report) = crate::waist_surgery::refine(&tree, code, size_dict, budget);
+    if config.surgery_iters > 0 {
+        let (refined, _report) = crate::waist_surgery::refine_capped(
+            &tree,
+            code,
+            size_dict,
+            std::time::Duration::MAX,
+            config.surgery_iters,
+        );
         return Some(refined);
     }
 
@@ -1003,7 +1011,7 @@ mod tests {
                 decomposition_type: DecompositionType::Tree,
                 initializer: Initializer::Random,
                 preprocess: false,
-                surgery_budget: 0.0,
+                surgery_iters: 0,
             };
             let returned = optimize_treesa(&code, &size_dict, &config).unwrap();
             let cc = contraction_complexity(&returned, &size_dict, &code.ixs);
@@ -1853,15 +1861,15 @@ mod tests {
     fn test_treesa_pipeline_defaults() {
         let config = TreeSA::default();
         assert!(config.preprocess);
-        assert_eq!(config.surgery_budget, 0.0);
+        assert_eq!(config.surgery_iters, 0);
         let fast = TreeSA::fast();
         assert!(fast.preprocess);
-        assert_eq!(fast.surgery_budget, 0.0);
+        assert_eq!(fast.surgery_iters, 0);
         let tuned = TreeSA::default()
             .with_preprocess(false)
-            .with_surgery_budget(30.0);
+            .with_surgery_iters(30);
         assert!(!tuned.preprocess);
-        assert_eq!(tuned.surgery_budget, 30.0);
+        assert_eq!(tuned.surgery_iters, 30);
     }
 
     /// Pins the preset-level preprocess contract: `TreeSA::default()` (and
@@ -2012,8 +2020,12 @@ mod tests {
         EinCode::new(ixs, vec![])
     }
 
+    /// `surgery_iters > 0` is fully deterministic (internal RNG seeds are
+    /// fixed and no wall-clock deadline binds `optimize_treesa`'s cap): two
+    /// runs of the same config produce byte-identical trees. It is also
+    /// never worse than the no-surgery baseline.
     #[test]
-    fn test_surgery_budget_never_worse() {
+    fn test_surgery_iters_deterministic_and_never_worse() {
         use crate::contraction_complexity;
         // 4x4 periodic grid — a frozen-waist-style instance where surgery acts.
         let code = grid_code(4, 4);
@@ -2022,11 +2034,19 @@ mod tests {
         let base_cfg = TreeSA::fast();
         let base = optimize_treesa(&code, &sizes, &base_cfg).unwrap();
         let base_tc = contraction_complexity(&base, &sizes, &code.ixs).tc;
-        let cfg = TreeSA::fast().with_surgery_budget(2.0);
-        let refined = optimize_treesa(&code, &sizes, &cfg).unwrap();
-        let refined_tc = contraction_complexity(&refined, &sizes, &code.ixs).tc;
+
+        let cfg = TreeSA::fast().with_surgery_iters(5);
+        let refined_a = optimize_treesa(&code, &sizes, &cfg).unwrap();
+        let refined_b = optimize_treesa(&code, &sizes, &cfg).unwrap();
+        assert_eq!(
+            format!("{refined_a:?}"),
+            format!("{refined_b:?}"),
+            "surgery_iters > 0 must be deterministic across runs"
+        );
+
+        let refined_tc = contraction_complexity(&refined_a, &sizes, &code.ixs).tc;
         assert!(refined_tc <= base_tc + 1e-9, "{refined_tc} > {base_tc}");
-        assert_eq!(refined.leaf_count(), code.num_tensors());
+        assert_eq!(refined_a.leaf_count(), code.num_tensors());
     }
 
     #[test]
@@ -2036,26 +2056,10 @@ mod tests {
             vec![],
         );
         let sizes: HashMap<usize, usize> = (0..4).map(|l| (l, 8)).collect();
-        let cfg = TreeSA::fast(); // surgery_budget == 0.0
+        let cfg = TreeSA::fast(); // surgery_iters == 0
         let a = optimize_treesa(&code, &sizes, &cfg).unwrap();
         let b = optimize_treesa(&code, &sizes, &cfg).unwrap();
         assert_eq!(format!("{a:?}"), format!("{b:?}"));
-    }
-
-    /// Regression for the `Duration::from_secs_f64` panic on
-    /// `surgery_budget = f64::INFINITY` (unreachable from Rust with a finite
-    /// budget, but directly reachable from Python via
-    /// `TreeSA(surgery_budget=float("inf"))`). Uses a 2-tensor chain so that
-    /// `waist_surgery::refine`'s `n < 3` early return fires immediately,
-    /// regardless of how large the converted `Duration` budget is.
-    #[test]
-    fn test_surgery_budget_infinity_does_not_panic() {
-        let code = EinCode::new(vec![vec!['i', 'j'], vec!['j', 'k']], vec!['i', 'k']);
-        let sizes: HashMap<char, usize> = [('i', 2), ('j', 2), ('k', 2)].into();
-        let config = TreeSA::fast().with_surgery_budget(f64::INFINITY);
-        let result = optimize_treesa(&code, &sizes, &config);
-        assert!(result.is_some());
-        assert_eq!(result.unwrap().leaf_count(), 2);
     }
 
     /// Regression: manually setting `decomposition_type: Path` while leaving

--- a/omeco/src/treesa.rs
+++ b/omeco/src/treesa.rs
@@ -767,9 +767,7 @@ pub fn optimize_treesa<L: Label>(
 
     if config.surgery_iters > 0 {
         let budget = std::time::Duration::MAX;
-        let (refined, _report) =
-            refine_capped(&tree, code, size_dict, budget, config.surgery_iters);
-        return Some(refined);
+        return Some(refine_capped(&tree, code, size_dict, budget, config.surgery_iters).0);
     }
 
     Some(tree)
@@ -2101,5 +2099,33 @@ mod tests {
         assert_eq!(tree.leaf_count(), 3);
         let cc = crate::contraction_complexity(&tree, &sizes, &code.ixs);
         assert!(cc.tc.is_finite());
+    }
+
+    #[test]
+    fn test_rw_weighted_score_optimizes() {
+        let code = EinCode::new(
+            vec![
+                vec!['a', 'b'],
+                vec!['b', 'c'],
+                vec!['c', 'd'],
+                vec!['d', 'a'],
+            ],
+            vec![],
+        );
+        let sizes: HashMap<char, usize> = [('a', 4), ('b', 4), ('c', 4), ('d', 4)].into();
+        let score = ScoreFunction {
+            rw_weight: 1.0,
+            ..ScoreFunction::default()
+        };
+        let config = TreeSA {
+            score,
+            ntrials: 1,
+            niters: 10,
+            ..TreeSA::fast()
+        };
+        let tree = optimize_treesa(&code, &sizes, &config).unwrap();
+        assert_eq!(tree.leaf_count(), 4);
+        let cc = crate::contraction_complexity(&tree, &sizes, &code.ixs);
+        assert!(cc.rwc.is_finite());
     }
 }

--- a/omeco/src/treesa.rs
+++ b/omeco/src/treesa.rs
@@ -33,11 +33,25 @@ pub struct TreeSA {
     /// Run the structural simplification front-end before annealing
     /// (simplify → optimize the reduced network → splice back). Deterministic
     /// and exactness-preserving; see [`crate::preprocess`].
+    ///
+    /// [`optimize_treesa`] auto-skips this step (treating it as `false`)
+    /// whenever `decomposition_type` is [`DecompositionType::Path`], even if
+    /// this field is set to `true`: splice does not preserve the
+    /// path-decomposition guarantee. See [`TreeSA::path`].
     pub preprocess: bool,
     /// Wall-clock budget in seconds for the waist-surgery post-pass on the
     /// selected tree; `0.0` disables it. With a positive budget the result is
     /// never worse than without, but is not reproducible across machines.
+    /// `f64::INFINITY` (or any value too large to represent as a
+    /// [`std::time::Duration`]) is treated as an effectively unlimited
+    /// budget rather than causing a panic.
     /// See [`crate::waist_surgery`].
+    ///
+    /// # Determinism
+    ///
+    /// The surgery pass's RNG seed is fixed, but how much work fits inside
+    /// the budget depends on wall-clock speed, so results with a positive
+    /// budget are **not** reproducible across machines or loads.
     pub surgery_budget: f64,
 }
 
@@ -143,12 +157,44 @@ impl TreeSA {
     }
 
     /// Enable or disable the structural simplification front-end.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use omeco::{optimize_treesa, EinCode, TreeSA};
+    /// use std::collections::HashMap;
+    ///
+    /// let code = EinCode::new(
+    ///     vec![vec!['i', 'j'], vec!['j', 'k'], vec!['k', 'l']],
+    ///     vec!['i', 'l'],
+    /// );
+    /// let sizes: HashMap<char, usize> = [('i', 2), ('j', 2), ('k', 2), ('l', 2)].into();
+    /// let config = TreeSA::fast().with_preprocess(false);
+    /// let tree = optimize_treesa(&code, &sizes, &config).unwrap();
+    /// assert_eq!(tree.leaf_count(), 3);
+    /// ```
     pub fn with_preprocess(mut self, preprocess: bool) -> Self {
         self.preprocess = preprocess;
         self
     }
 
     /// Set the waist-surgery wall-clock budget in seconds (0.0 disables).
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use omeco::{optimize_treesa, EinCode, TreeSA};
+    /// use std::collections::HashMap;
+    ///
+    /// let code = EinCode::new(
+    ///     vec![vec!['i', 'j'], vec!['j', 'k'], vec!['k', 'l']],
+    ///     vec!['i', 'l'],
+    /// );
+    /// let sizes: HashMap<char, usize> = [('i', 2), ('j', 2), ('k', 2), ('l', 2)].into();
+    /// let config = TreeSA::fast().with_surgery_budget(0.1);
+    /// let tree = optimize_treesa(&code, &sizes, &config).unwrap();
+    /// assert_eq!(tree.leaf_count(), 3);
+    /// ```
     pub fn with_surgery_budget(mut self, seconds: f64) -> Self {
         self.surgery_budget = seconds;
         self
@@ -694,12 +740,19 @@ fn get_child_labels<L: Label>(nested: &NestedEinsum<L>, original_ixs: &[Vec<L>])
 /// positive [`TreeSA::surgery_budget`] additionally refines the result with
 /// [`crate::waist_surgery::refine`] (never worse; wall-clock dependent, so
 /// results with surgery enabled are not reproducible across machines).
+///
+/// [`TreeSA::preprocess`] is automatically treated as disabled whenever
+/// [`TreeSA::decomposition_type`] is [`DecompositionType::Path`], even if the
+/// field was manually set to `true`: [`crate::preprocess::splice`] is
+/// decomposition-agnostic and can turn a path decomposition into a
+/// non-path tree (see the doc comment on [`TreeSA::path`]).
 pub fn optimize_treesa<L: Label>(
     code: &EinCode<L>,
     size_dict: &HashMap<L, usize>,
     config: &TreeSA,
 ) -> Option<NestedEinsum<L>> {
-    let tree = if config.preprocess {
+    let preprocess = config.preprocess && config.decomposition_type != DecompositionType::Path;
+    let tree = if preprocess {
         let simplified = simplify(code, size_dict);
         let reduced = optimize_treesa_core(&simplified.code, size_dict, config)?;
         splice(&reduced, &simplified.subtrees)
@@ -708,7 +761,8 @@ pub fn optimize_treesa<L: Label>(
     };
 
     if config.surgery_budget > 0.0 {
-        let budget = std::time::Duration::from_secs_f64(config.surgery_budget);
+        let budget = std::time::Duration::try_from_secs_f64(config.surgery_budget)
+            .unwrap_or(std::time::Duration::MAX);
         let (refined, _report) = crate::waist_surgery::refine(&tree, code, size_dict, budget);
         return Some(refined);
     }
@@ -1986,5 +2040,46 @@ mod tests {
         let a = optimize_treesa(&code, &sizes, &cfg).unwrap();
         let b = optimize_treesa(&code, &sizes, &cfg).unwrap();
         assert_eq!(format!("{a:?}"), format!("{b:?}"));
+    }
+
+    /// Regression for the `Duration::from_secs_f64` panic on
+    /// `surgery_budget = f64::INFINITY` (unreachable from Rust with a finite
+    /// budget, but directly reachable from Python via
+    /// `TreeSA(surgery_budget=float("inf"))`). Uses a 2-tensor chain so that
+    /// `waist_surgery::refine`'s `n < 3` early return fires immediately,
+    /// regardless of how large the converted `Duration` budget is.
+    #[test]
+    fn test_surgery_budget_infinity_does_not_panic() {
+        let code = EinCode::new(vec![vec!['i', 'j'], vec!['j', 'k']], vec!['i', 'k']);
+        let sizes: HashMap<char, usize> = [('i', 2), ('j', 2), ('k', 2)].into();
+        let config = TreeSA::fast().with_surgery_budget(f64::INFINITY);
+        let result = optimize_treesa(&code, &sizes, &config);
+        assert!(result.is_some());
+        assert_eq!(result.unwrap().leaf_count(), 2);
+    }
+
+    /// Regression: manually setting `decomposition_type: Path` while leaving
+    /// `preprocess: true` (the default) must not silently void the
+    /// path-decomposition guarantee — `optimize_treesa` auto-skips
+    /// preprocessing in this case, same as the `TreeSA::path()` preset.
+    #[test]
+    fn test_path_decomposition_holds_with_preprocess_true() {
+        let code = EinCode::new(
+            vec![
+                vec!['a', 'b'],
+                vec!['b', 'c'],
+                vec!['c', 'd'],
+                vec!['d', 'e'],
+            ],
+            vec!['a', 'e'],
+        );
+        let sizes: HashMap<char, usize> = [('a', 2), ('b', 2), ('c', 2), ('d', 2), ('e', 2)].into();
+        let mut config = TreeSA::fast();
+        config.initializer = Initializer::Random;
+        config.decomposition_type = DecompositionType::Path;
+        config.preprocess = true; // manually left on, unlike TreeSA::path()
+        let tree = optimize_treesa(&code, &sizes, &config).unwrap();
+        assert!(tree.is_path_decomposition());
+        assert_eq!(tree.leaf_count(), 4);
     }
 }

--- a/omeco/src/treesa.rs
+++ b/omeco/src/treesa.rs
@@ -29,6 +29,15 @@ pub struct TreeSA {
     pub score: ScoreFunction,
     /// Decomposition type (Tree or Path)
     pub decomposition_type: DecompositionType,
+    /// Run the structural simplification front-end before annealing
+    /// (simplify → optimize the reduced network → splice back). Deterministic
+    /// and exactness-preserving; see [`crate::preprocess`].
+    pub preprocess: bool,
+    /// Wall-clock budget in seconds for the waist-surgery post-pass on the
+    /// selected tree; `0.0` disables it. With a positive budget the result is
+    /// never worse than without, but is not reproducible across machines.
+    /// See [`crate::waist_surgery`].
+    pub surgery_budget: f64,
 }
 
 /// Method for initializing the contraction tree.
@@ -52,6 +61,8 @@ impl Default for TreeSA {
             initializer: Initializer::Greedy,
             score: ScoreFunction::default(),
             decomposition_type: DecompositionType::Tree,
+            preprocess: true,
+            surgery_budget: 0.0,
         }
     }
 }
@@ -72,6 +83,8 @@ impl TreeSA {
             initializer,
             score,
             decomposition_type: DecompositionType::Tree,
+            preprocess: true,
+            surgery_budget: 0.0,
         }
     }
 
@@ -116,6 +129,18 @@ impl TreeSA {
     /// Set the inverse temperature schedule.
     pub fn with_betas(mut self, betas: Vec<f64>) -> Self {
         self.betas = betas;
+        self
+    }
+
+    /// Enable or disable the structural simplification front-end.
+    pub fn with_preprocess(mut self, preprocess: bool) -> Self {
+        self.preprocess = preprocess;
+        self
+    }
+
+    /// Set the waist-surgery wall-clock budget in seconds (0.0 disables).
+    pub fn with_surgery_budget(mut self, seconds: f64) -> Self {
+        self.surgery_budget = seconds;
         self
     }
 }
@@ -880,6 +905,8 @@ mod tests {
                 score: ScoreFunction::default(),
                 decomposition_type: DecompositionType::Tree,
                 initializer: Initializer::Random,
+                preprocess: false,
+                surgery_budget: 0.0,
             };
             let returned = optimize_treesa(&code, &size_dict, &config).unwrap();
             let cc = contraction_complexity(&returned, &size_dict, &code.ixs);
@@ -1723,5 +1750,20 @@ mod tests {
         let sizes: HashMap<char, usize> = [('i', 4), ('j', 4)].into();
         let seed: NestedEinsum<char> = NestedEinsum::leaf(0);
         assert!(prepare_warm_anneal(&code, &sizes, &seed).is_none());
+    }
+
+    #[test]
+    fn test_treesa_pipeline_defaults() {
+        let config = TreeSA::default();
+        assert!(config.preprocess);
+        assert_eq!(config.surgery_budget, 0.0);
+        let fast = TreeSA::fast();
+        assert!(fast.preprocess);
+        assert_eq!(fast.surgery_budget, 0.0);
+        let tuned = TreeSA::default()
+            .with_preprocess(false)
+            .with_surgery_budget(30.0);
+        assert!(!tuned.preprocess);
+        assert_eq!(tuned.surgery_budget, 30.0);
     }
 }

--- a/omeco/src/treesa.rs
+++ b/omeco/src/treesa.rs
@@ -7,6 +7,7 @@
 use crate::eincode::{EinCode, NestedEinsum};
 use crate::expr_tree::{apply_rule_mut, DecompositionType, ExprTree, Rule, ScratchSpace};
 use crate::greedy::{optimize_greedy, GreedyMethod};
+use crate::preprocess::{simplify, splice};
 use crate::score::ScoreFunction;
 use crate::utils::fast_log2sumexp2;
 use crate::Label;
@@ -677,7 +678,32 @@ fn get_child_labels<L: Label>(nested: &NestedEinsum<L>, original_ixs: &[Vec<L>])
 }
 
 /// Optimize an EinCode using TreeSA.
+///
+/// By default this runs the full pipeline: structural simplification
+/// ([`crate::preprocess::simplify`]), the annealing trial loop on the reduced
+/// network, and splice-back — controlled by [`TreeSA::preprocess`]. A positive
+/// [`TreeSA::surgery_budget`] additionally refines the result with
+/// [`crate::waist_surgery::refine`].
 pub fn optimize_treesa<L: Label>(
+    code: &EinCode<L>,
+    size_dict: &HashMap<L, usize>,
+    config: &TreeSA,
+) -> Option<NestedEinsum<L>> {
+    let tree = if config.preprocess {
+        let simplified = simplify(code, size_dict);
+        let reduced = optimize_treesa_core(&simplified.code, size_dict, config)?;
+        splice(&reduced, &simplified.subtrees)
+    } else {
+        optimize_treesa_core(code, size_dict, config)?
+    };
+    Some(tree)
+}
+
+/// Bare TreeSA trial loop, without the structural-simplification front-end.
+///
+/// Used directly by [`optimize_treesa`] when [`TreeSA::preprocess`] is `false`,
+/// and by the preprocessed path to optimize the already-reduced network.
+fn optimize_treesa_core<L: Label>(
     code: &EinCode<L>,
     size_dict: &HashMap<L, usize>,
     config: &TreeSA,
@@ -1765,5 +1791,109 @@ mod tests {
             .with_surgery_budget(30.0);
         assert!(!tuned.preprocess);
         assert_eq!(tuned.surgery_budget, 30.0);
+    }
+
+    #[test]
+    fn test_default_pipeline_preprocess_preserves_interfaces() {
+        // Matrix chain: simplify collapses it; the spliced tree must keep all leaves.
+        let code = EinCode::new(
+            vec![
+                vec!['a', 'b'],
+                vec!['b', 'c'],
+                vec!['c', 'd'],
+                vec!['d', 'e'],
+            ],
+            vec!['a', 'e'],
+        );
+        let sizes: HashMap<char, usize> = [('a', 2), ('b', 2), ('c', 2), ('d', 2), ('e', 2)].into();
+        let tree = optimize_treesa(&code, &sizes, &TreeSA::fast()).unwrap();
+        assert_eq!(tree.leaf_count(), 4);
+        let cc = crate::contraction_complexity(&tree, &sizes, &code.ixs);
+        assert!(cc.tc.is_finite());
+    }
+
+    /// Loader for the shared benchmark graph JSON (`{ "ixs", "iy", "sizes" }`,
+    /// as read by `omeco/examples/benchmark.rs`), not the `edge_list` schema
+    /// used only by `reg3_220.json` (see `test_reg3_220_treesa` in `lib.rs`).
+    fn load_benchmark_graph(name: &str) -> (EinCode<usize>, HashMap<usize, usize>) {
+        let graph_json =
+            std::fs::read_to_string(format!("../benchmarks/graphs/{name}.json")).unwrap();
+        let graph: serde_json::Value = serde_json::from_str(&graph_json).unwrap();
+        let ixs: Vec<Vec<usize>> = graph["ixs"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|ix| {
+                ix.as_array()
+                    .unwrap()
+                    .iter()
+                    .map(|l| l.as_u64().unwrap() as usize)
+                    .collect()
+            })
+            .collect();
+        let iy: Vec<usize> = graph["iy"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|l| l.as_u64().unwrap() as usize)
+            .collect();
+        let sizes: HashMap<usize, usize> = graph["sizes"]
+            .as_object()
+            .unwrap()
+            .iter()
+            .map(|(k, v)| (k.parse::<usize>().unwrap(), v.as_u64().unwrap() as usize))
+            .collect();
+        (EinCode::new(ixs, iy), sizes)
+    }
+
+    #[test]
+    fn test_default_pipeline_quality_on_benchmark_graphs() {
+        // Spec §4: default (preprocess on) is within 0.5 bits of the bare loop on
+        // the benchmark graphs; exact equality where simplify is a no-op.
+        //
+        // Deviation from task-3-brief.md Step 1: the brief paired "reg3_50" with
+        // `no_op: true`, assuming 3-regular graphs are never simplifiable. That
+        // holds for a graph with an even total degree sum, but
+        // `benchmarks/graphs/reg3_50.json` (50 vertices, odd) carries one
+        // rank-1 "defect" tensor to balance parity; simplify's rank-non-increasing
+        // rule fuses it into a neighbour (50 -> 46 tensors), so tc_pre and tc_raw
+        // are close but not bit-identical (verified: diff ~0.045 bits, well inside
+        // the 0.5-bit tolerance). Swapped in "petersen" (10 vertices, uniformly
+        // rank-3, empirically confirmed n_reduced == n_original) as the true
+        // no-op case; reg3_50 would still pass under the tolerance branch.
+        for (name, no_op) in [("grid_4x4", false), ("petersen", true)] {
+            let (code, sizes) = load_benchmark_graph(name);
+            let cfg = TreeSA::fast();
+            let with_pre = optimize_treesa(&code, &sizes, &cfg).unwrap();
+            let without =
+                optimize_treesa(&code, &sizes, &cfg.clone().with_preprocess(false)).unwrap();
+            let tc_pre = crate::contraction_complexity(&with_pre, &sizes, &code.ixs).tc;
+            let tc_raw = crate::contraction_complexity(&without, &sizes, &code.ixs).tc;
+            if no_op {
+                assert!(
+                    (tc_pre - tc_raw).abs() < 1e-9,
+                    "{name}: {tc_pre} vs {tc_raw}"
+                );
+            } else {
+                assert!(tc_pre <= tc_raw + 0.5, "{name}: {tc_pre} > {tc_raw} + 0.5");
+            }
+        }
+    }
+
+    #[test]
+    fn test_preprocess_off_matches_core_loop() {
+        let code = EinCode::new(
+            vec![vec!['a', 'b'], vec!['b', 'c'], vec!['c', 'a']],
+            Vec::<char>::new(),
+        );
+        let sizes: HashMap<char, usize> = [('a', 4), ('b', 4), ('c', 4)].into();
+        let config = TreeSA::fast().with_preprocess(false);
+        let via_public = optimize_treesa(&code, &sizes, &config).unwrap();
+        let via_core = optimize_treesa_core(&code, &sizes, &config).unwrap();
+        assert_eq!(
+            format!("{via_public:?}"),
+            format!("{via_core:?}"),
+            "preprocess=false must be byte-identical to the bare trial loop"
+        );
     }
 }

--- a/omeco/src/waist_surgery.rs
+++ b/omeco/src/waist_surgery.rs
@@ -667,6 +667,9 @@ struct Refiner<'a> {
     log2_sizes: &'a [f64],
     start: Instant,
     budget: Duration,
+    /// Maximum number of surgery iterations to start (0 = uncapped). Checked
+    /// against `report.surgery_calls` before each iteration begins.
+    max_iters: u64,
     rng: SmallRng,
     report: WaistReport,
 }
@@ -917,7 +920,10 @@ impl Refiner<'_> {
 ///
 /// The RNG seed is fixed, but how much work fits inside `budget` depends on
 /// wall-clock speed, so results are **not** reproducible across machines or
-/// loads — only the never-worse guarantee is.
+/// loads — only the never-worse guarantee is. For a fully deterministic,
+/// machine-independent cap use [`refine_capped`] with a positive `max_iters`
+/// (this function is a thin delegate: `refine_capped(tree, code, sizes,
+/// budget, 0)`, i.e. `0` = uncapped).
 ///
 /// # Example
 ///
@@ -942,6 +948,49 @@ pub fn refine<L: Label>(
     code: &EinCode<L>,
     sizes: &HashMap<L, usize>,
     budget: Duration,
+) -> (NestedEinsum<L>, WaistReport) {
+    refine_capped(tree, code, sizes, budget, 0)
+}
+
+/// Refine a contraction tree by repeated waist surgery, identical to
+/// [`refine`] except that at most `max_iters` surgery iterations are started
+/// (`0` = uncapped, matching `refine`'s behavior exactly).
+///
+/// Each iteration increments [`WaistReport::surgery_calls`] once, before
+/// doing any work; capping stops the loop **before** starting an iteration
+/// once that counter has reached `max_iters`, so the guarantee is exactly
+/// `report.surgery_calls <= max_iters` whenever `max_iters > 0`.
+///
+/// Note that `max_iters` bounds *iterations*, not wall-clock time: `budget`
+/// still applies within each iteration (FM and rebuild-annealing loops), so
+/// pass a generous budget (e.g. [`Duration::MAX`]) if you want the iteration
+/// count to be the only limiting factor — that combination is fully
+/// deterministic and machine-independent, unlike a positive `budget` alone.
+///
+/// # Example
+///
+/// ```
+/// use omeco::waist_surgery::refine_capped;
+/// use omeco::{optimize_code, EinCode, GreedyMethod};
+/// use std::collections::HashMap;
+/// use std::time::Duration;
+///
+/// let code = EinCode::new(
+///     vec![vec!['i', 'j'], vec!['j', 'k'], vec!['k', 'l']],
+///     vec!['i', 'l'],
+/// );
+/// let sizes: HashMap<char, usize> = [('i', 2), ('j', 2), ('k', 2), ('l', 2)].into();
+/// let seed = optimize_code(&code, &sizes, &GreedyMethod::default()).unwrap();
+/// let (refined, report) = refine_capped(&seed, &code, &sizes, Duration::MAX, 2);
+/// assert_eq!(refined.leaf_count(), 3);
+/// assert!(report.surgery_calls <= 2);
+/// ```
+pub fn refine_capped<L: Label>(
+    tree: &NestedEinsum<L>,
+    code: &EinCode<L>,
+    sizes: &HashMap<L, usize>,
+    budget: Duration,
+    max_iters: u64,
 ) -> (NestedEinsum<L>, WaistReport) {
     let n = code.num_tensors();
     let mut report = WaistReport {
@@ -1005,12 +1054,16 @@ pub fn refine<L: Label>(
         log2_sizes: &log2_sizes,
         start: Instant::now(),
         budget,
+        max_iters,
         rng: SmallRng::seed_from_u64(RNG_SEED),
         report,
     };
 
     let mut stale: u64 = 0;
-    while !refiner.out_of_time() && stale < MAX_STALE_ITERS {
+    while !refiner.out_of_time()
+        && stale < MAX_STALE_ITERS
+        && (refiner.max_iters == 0 || refiner.report.surgery_calls < refiner.max_iters)
+    {
         let Some(incumbent) = nested_to_expr_tree(&best, &id_label_map) else {
             break;
         };
@@ -1378,6 +1431,41 @@ mod tests {
         assert_eq!(report.surgery_calls, 0);
     }
 
+    /// `refine_capped` with a generous budget and a small `max_iters` must
+    /// stop starting new surgery iterations once the counter reaches the cap.
+    #[test]
+    fn test_refine_capped_bounds_surgery_calls() {
+        let code = grid(4, 4);
+        let sizes = uniform_sizes(&code, 2);
+        let seed = optimize_code(&code, &sizes, &GreedyMethod::default()).unwrap();
+        let (_refined, report) = refine_capped(&seed, &code, &sizes, Duration::from_secs(3600), 3);
+        assert!(
+            report.surgery_calls <= 3,
+            "surgery_calls={} > max_iters=3",
+            report.surgery_calls
+        );
+    }
+
+    /// `refine(...)` must be byte-identical to `refine_capped(..., 0)`: the
+    /// former is documented as a thin delegate to the latter.
+    #[test]
+    fn test_refine_delegates_uncapped() {
+        let code = EinCode::new(
+            vec![vec![0usize, 1], vec![1, 2], vec![2, 3], vec![3, 4]],
+            vec![0, 4],
+        );
+        let sizes = uniform_sizes(&code, 2);
+        let seed = optimize_code(&code, &sizes, &GreedyMethod::default()).unwrap();
+        // A generous, identical budget on both sides: this tiny network's
+        // surgery loop terminates deterministically (MAX_STALE_ITERS) well
+        // inside it, so timing jitter cannot make the two calls diverge.
+        let (via_refine, report_refine) = refine(&seed, &code, &sizes, Duration::from_secs(3600));
+        let (via_capped, report_capped) =
+            refine_capped(&seed, &code, &sizes, Duration::from_secs(3600), 0);
+        assert_eq!(format!("{via_refine:?}"), format!("{via_capped:?}"));
+        assert_eq!(report_refine, report_capped);
+    }
+
     #[test]
     fn test_extract_waist_finds_non_root_argmax() {
         let right = ExprTree::node(
@@ -1435,6 +1523,7 @@ mod tests {
             log2_sizes: &log2,
             start: Instant::now(),
             budget: Duration::ZERO,
+            max_iters: 0,
             rng: SmallRng::seed_from_u64(RNG_SEED),
             report: WaistReport {
                 n_original: code.num_tensors(),
@@ -1464,6 +1553,7 @@ mod tests {
             log2_sizes: &log2,
             start: Instant::now(),
             budget: Duration::from_secs(1),
+            max_iters: 0,
             rng: SmallRng::seed_from_u64(RNG_SEED),
             report: WaistReport {
                 n_original: code.num_tensors(),
@@ -1521,6 +1611,7 @@ mod tests {
             log2_sizes: &log2,
             start: Instant::now(),
             budget: Duration::from_secs(2),
+            max_iters: 0,
             rng: SmallRng::seed_from_u64(RNG_SEED),
             report: WaistReport {
                 n_original: code.num_tensors(),
@@ -1581,6 +1672,7 @@ mod tests {
             log2_sizes: &log2,
             start: Instant::now(),
             budget: Duration::from_secs(2),
+            max_iters: 0,
             rng: SmallRng::seed_from_u64(RNG_SEED),
             report: WaistReport {
                 n_original: code.num_tensors(),
@@ -1658,6 +1750,7 @@ mod tests {
             log2_sizes: &log2,
             start: Instant::now(),
             budget: Duration::from_secs(1),
+            max_iters: 0,
             rng: SmallRng::seed_from_u64(RNG_SEED),
             report: WaistReport {
                 n_original: code.num_tensors(),
@@ -1714,6 +1807,7 @@ mod tests {
             log2_sizes: &log2,
             start: Instant::now(),
             budget: Duration::from_secs(1),
+            max_iters: 0,
             rng: SmallRng::seed_from_u64(RNG_SEED),
             report: WaistReport {
                 n_original: code.num_tensors(),


### PR DESCRIPTION
Implements docs/superpowers/specs/2026-07-29-usability-post-alignment-design.md. Default change: preprocess=true (changelog). surgery_budget opt-in. Python parity + simplify_then_optimize/waist_refine. Alignment rule retired, JSON interop kept. Patch bump 0.2.7.