### PR TITLE
Make waist surgery a cold TreeSA update

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -21,11 +21,13 @@ jobs:
         run: cargo install cargo-tarpaulin
       
       - name: Generate coverage
-        run: cargo tarpaulin --all-features --packages omeco --timeout 300 --out xml --exclude-files "omeco/examples/*"
+        # LLVM instrumentation preserves source mappings across the Rayon trial
+        # workers. The ptrace engine reports executed multiline call arguments
+        # as misses, which makes patch coverage depend on formatting.
+        run: cargo tarpaulin --engine llvm --all-features --packages omeco --timeout 300 --out xml --exclude-files "omeco/examples/*"
       
       - name: Upload to codecov.io
         uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false
-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,20 +9,31 @@ cost). Restore the old behavior with `preprocess: false`.
 
 - New `TreeSA.surgery_iters` (default `0`/off): number of interleaved
   anneal–surgery rounds (Algorithm 1 of the companion paper) run on the
-  pipeline's tree. Each round is one waist-surgery iteration followed by a
-  full warm-started annealing pass, so a round costs about one extra anneal;
-  the best tree seen is returned, so more rounds are never worse. Fully
+  reduced-network tree. Each round is one waist-surgery iteration followed by
+  a cold span-gated fine-tuning pass with an incumbent ratchet. After
+  splice-back, the candidate is guarded against the rounds-off baseline; the
+  standalone reduced-network loop is monotone in its round count. Fully
   deterministic — rounds are counted, never timed — and auto-skipped for
   `DecompositionType::Path` configs, which the loop cannot preserve. `TreeSA`
   has no wall-clock knob; the low-level `waist_surgery::refine`/
   `refine_capped` APIs are unchanged and keep their `Duration` budget for
   power users.
+- New `TreeSA.surgery_probability` (default `0.0`/off): mixes waist surgery
+  directly into TreeSA. At each sweep, the configured probability replaces
+  the local sweep with one waist-guided leaf prune-and-regraft move, accepted
+  at the current inverse temperature. The rule never restarts cooling, invokes
+  a timer, or launches a nested anneal; Rust and Python expose the same setting.
 - New `treesa::anneal_surgery_rounds` + `RoundsReport`: the same interleaved
-  loop as a standalone function, with a per-round score trace.
-- Python: `TreeSA(preprocess=..., surgery_iters=...)`,
+  loop as a standalone function, with separate per-round surgery candidate,
+  raw fine-tuning endpoint, and retained-incumbent traces.
+- Python: `TreeSA(preprocess=..., surgery_iters=..., surgery_probability=...)`,
   `simplify_then_optimize`, `waist_refine`, `SimplifyReport`, `WaistReport`.
+- Fixed Python `TreeSA()` to delegate its default β schedule to Rust
+  `TreeSA::default()` (`0..300`); the previous duplicate used `1..=300` and
+  could shift benchmark quality by several bits.
 - Committed paper-benchmark artifact under `benchmarks/paper/` (manifest,
   instances, deterministic runner, checker), plus a CI job that re-derives the
-  small `ci` set on every PR and fails on a single changed field.
+  small `ci` set on every PR and fails on a single changed field. A dedicated
+  `figure2b` set checks the paper mechanism and renders a static SVG.
 - `Label` now requires `Ord` (all built-in label types already qualify).
 - The Julia behavioral-alignment rule is retired; JSON interop is unchanged.

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .DEFAULT_GOAL := help
-.PHONY: help build build-release check fmt fmt-check clippy test check-all clean doc doc-private serve-docs python-dev python-dev-debug python-build python-test benchmark paper-bench paper-bench-check version bump-patch bump-minor bump-major release publish publish-crates publish-all github-release install-mdbook build-book serve-book clean-book
+.PHONY: help build build-release check fmt fmt-check clippy test check-all clean doc doc-private serve-docs python-dev python-dev-debug python-build python-test benchmark paper-bench paper-bench-check paper-figure2b-check paper-figure2b-plot version bump-patch bump-minor bump-major release publish publish-crates publish-all github-release install-mdbook build-book serve-book clean-book
 
 CARGO ?= cargo
 PYTHON ?= python3
@@ -44,6 +44,8 @@ help:
 	@printf "  benchmark         Run Python vs Julia benchmark\n"
 	@printf "  paper-bench       Regenerate the committed full paper benchmark artifact\n"
 	@printf "  paper-bench-check Re-run the ci set and verify it against the committed artifact\n"
+	@printf "  paper-figure2b-check Reproduce the Figure 2(b) surface-code trajectory\n"
+	@printf "  paper-figure2b-plot  Render the committed Figure 2(b) trajectory as SVG\n"
 	@printf "\nRelease targets:\n"
 	@printf "  version         Show current version\n"
 	@printf "  bump-patch      Bump patch version ($(VERSION) -> $(MAJOR).$(MINOR).$$(($(PATCH)+1)))\n"
@@ -124,6 +126,17 @@ paper-bench-check:
 	@tmp=$$(mktemp) && trap 'rm -f "$$tmp"' EXIT && \
 	$(PAPER_BENCH) --set ci --out "$$tmp" && \
 	$(PYTHON) benchmarks/paper/check.py "$$tmp" benchmarks/paper/expected/ci.json
+
+paper-figure2b-check:
+	@tmp=$$(mktemp) && trap 'rm -f "$$tmp"' EXIT && \
+	$(PAPER_BENCH) --set figure2b --out "$$tmp" && \
+	$(PYTHON) benchmarks/paper/verify_figure2b.py "$$tmp" && \
+	$(PYTHON) benchmarks/paper/check.py "$$tmp" benchmarks/paper/expected/figure2b.json
+
+paper-figure2b-plot:
+	$(PYTHON) benchmarks/paper/plot_figure2b.py \
+		benchmarks/paper/expected/figure2b.json \
+		benchmarks/paper/expected/figure2b.svg
 
 # Version management
 version:

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ omeco = "0.2"
 
 `TreeSA()` runs the full default pipeline (simplify, anneal, splice) with no
 tuning required. Give it a positive `surgery_iters` to run that many extra,
-deterministic anneal-surgery rounds (about one anneal each) for a result
+deterministic surgery and cold span-gated fine-tuning rounds for a result
 that's never worse — see the
 [Default Pipeline](https://GiggleLiu.github.io/omeco/algorithms/default-pipeline.html)
 page for what each stage does and when surgery helps:
@@ -65,6 +65,7 @@ sizes = {0: 100, 1: 200, 2: 50, 3: 100}
 
 tree = optimize_code(ixs, out, sizes, TreeSA())        # full default pipeline
 better = optimize_code(ixs, out, sizes, TreeSA(surgery_iters=3))  # + 3 anneal-surgery rounds
+mixed = optimize_code(ixs, out, sizes, TreeSA(surgery_probability=0.001))  # 0.1% surgery updates
 print(contraction_complexity(tree, ixs, sizes))
 ```
 
@@ -104,7 +105,7 @@ sliced_tree_dict = sliced.to_dict()  # Dict for the optimized sliced tree
 
 `TreeSA::default()` runs the full default pipeline (simplify, anneal,
 splice) with no tuning required. Chain `.with_surgery_iters(3)` to run that
-many extra, deterministic anneal-surgery rounds (about one anneal each) for a
+many extra, deterministic surgery and cold span-gated fine-tuning rounds for a
 result that's never worse — see the
 [Default Pipeline](https://GiggleLiu.github.io/omeco/algorithms/default-pipeline.html)
 page for what each stage does and when surgery helps:
@@ -127,6 +128,12 @@ sizes.insert('l', 100);
 let tree = optimize_code(&code, &sizes, &TreeSA::default()).unwrap();
 // + 3 anneal-surgery rounds
 let better = optimize_code(&code, &sizes, &TreeSA::default().with_surgery_iters(3)).unwrap();
+// replace 0.1% of local sweeps with same-temperature surgery updates
+let mixed = optimize_code(
+    &code,
+    &sizes,
+    &TreeSA::default().with_surgery_probability(0.001),
+).unwrap();
 let complexity = contraction_complexity(&tree, &sizes, &code.ixs);
 println!("Time: 2^{:.2}, Space: 2^{:.2}", complexity.tc, complexity.sc);
 ```
@@ -252,6 +259,8 @@ let result = optimize_code(&code, &sizes, &custom);
 - `ntrials`: Number of parallel trials (uses rayon)
 - `niters`: Iterations per temperature level
 - `score`: Scoring function with complexity weights
+- `surgery_probability`: Probability that a local sweep is replaced by one
+  global waist update at the current inverse temperature (`0.0` by default)
 
 ## Complexity Metrics
 

--- a/benchmarks/paper/README.md
+++ b/benchmarks/paper/README.md
@@ -3,9 +3,12 @@
 Every number in the paper's released-artifact table is produced here, by the
 released library, on the reader's own machine. There is no reference host and no
 recorded oracle: the artifact is a *program plus a manifest*, and reproducing
-that table means running it. The paper's headline campaign numbers are a
-different measurement — wall-clock-budgeted on one fixed host — and this
-directory does not claim to reproduce them; see
+that table means running it. The `figure2b` set separately reproduces the
+surface-code mechanism panel with a deterministic 32-round work budget: it
+must cross the panel's pre-surgery record and show an accepted rebuild causing
+a drop. It must also expose at least one uphill fine-tuning endpoint separately
+from the monotone retained incumbent. The broader headline campaign remains a
+wall-clock-budgeted measurement on one fixed host; see
 [Calibration vs the frozen campaign](#calibration-vs-the-frozen-campaign) for
 the size of the gap and why it is there. The outputs under `expected/` are committed only so that
 they can be *re-derived* — CI regenerates the `ci` one on every push and fails on
@@ -19,7 +22,11 @@ This directory is self-contained — manifest, instances, checker:
 | `manifest.json` | Which instances, which optimizer arms, which overrides. The only place a benchmark parameter may be set. |
 | `instances/` | The thirteen paper instances, as JSON tensor networks. |
 | `expected/ci.json` | The `ci` set's output, re-derived and compared by `make paper-bench-check` (and by CI). `expected/full.json` is what `make paper-bench` writes. |
+| `expected/figure2b.json` | The 32-round surface-code reproduction, checked numerically and by the Figure 2(b) semantic contract. |
+| `expected/figure2b.svg` | Static fixed-work rendering of that JSON: retained incumbent, raw fine-tuning endpoints, and accepted rebuilds. |
 | `check.py` | Compares two artifacts and exits nonzero on any disagreement. Standard library only, Python 3.8+. |
+| `verify_figure2b.py` | Verifies the record crossing, incumbent ratchet, and accepted-rebuild mechanism. |
+| `plot_figure2b.py` | Renders the checked JSON as a dependency-free vector figure. |
 | `README.md` | This file. |
 
 The runner itself is `omeco/examples/paper_bench.rs`, an example binary in the
@@ -65,12 +72,20 @@ cargo run --release --example paper_bench -p omeco -- \
     --manifest benchmarks/paper/manifest.json \
     --set full \
     --out full.json
+
+# Figure 2(b): deterministic surfacecode_d21 trajectory (32 rounds).
+cargo run --release --example paper_bench -p omeco -- \
+    --manifest benchmarks/paper/manifest.json \
+    --set figure2b \
+    --out figure2b.json
+python3 benchmarks/paper/verify_figure2b.py figure2b.json
+python3 benchmarks/paper/plot_figure2b.py figure2b.json figure2b.svg
 ```
 
 Flags:
 
 - `--manifest <file>` — manifest to read (required).
-- `--set <name>` — set within the manifest, `ci` or `full` (required).
+- `--set <name>` — set within the manifest, `ci`, `figure2b`, or `full` (required).
 - `--out <file>` — where to write the JSON artifact (required).
 - `--repo-root <dir>` — root that instance paths in the manifest resolve
   against. Defaults to `.`, so the commands above must be run from the
@@ -81,10 +96,12 @@ wrong — an unknown flag, a missing instance file, malformed JSON, a mistyped
 manifest key — prints a message naming the problem and exits with status **2**.
 The runner never reports a typo by silently falling back to a default.
 
-Two Make targets wrap the same commands:
+Four Make targets wrap the same commands:
 
 ```bash
 make paper-bench-check  # ci set -> a temporary file -> check.py against expected/ci.json
+make paper-figure2b-check  # 32 rounds -> semantic verifier + exact artifact check
+make paper-figure2b-plot   # committed JSON -> publication-ready static SVG
 make paper-bench        # full set -> expected/full.json (~21 min, see below)
 ```
 
@@ -107,14 +124,16 @@ a result, and on any float leaf differing by more than a **relative** `1e-9`
 |---|---|
 | `greedy` | `GreedyMethod::default()` — the cheap baseline. |
 | `treesa` | `TreeSA::default()` with the manifest's overrides and `surgery_iters: 0` — annealing alone. |
-| `treesa_rounds` | The `treesa` result of the *same* configuration, then `rounds` interleaved anneal–surgery rounds (`anneal_surgery_rounds`, the paper's Algorithm 1). |
+| `treesa_rounds` | The reduced-network `treesa` result of the *same* configuration, then `rounds` interleaved surgery and cold span-gated fine-tuning rounds (`anneal_surgery_rounds`, the paper's Algorithm 1), then splice-back. |
+| `treesa_surgery_rule` | One `TreeSA::default()` run with `surgery_probability` set from the required manifest `probability`; surgery replaces local sweeps at the current temperature. |
 | `treewidth` | `Treewidth::default()`, on instances flagged `"treewidth": true` only. |
 
-`treesa` and `treesa_rounds` are deliberately built from the same seed
-computation, so a row pair at equal `ntrials`/`niters` isolates exactly what the
-rounds loop adds. The runner calls `anneal_surgery_rounds` directly rather than
-setting `TreeSA::surgery_iters`; the two are bit-identical (a library test pins
-this), and the direct call additionally exposes the per-round trajectory.
+`treesa` and `treesa_rounds` are deliberately built from the same reduced-network
+seed computation, so a row pair at equal `ntrials`/`niters` isolates exactly what
+the rounds loop adds. Both splice back only after their reduced-network search.
+The runner composes `simplify`, `anneal_surgery_rounds`, and `splice` directly;
+that is bit-identical to setting `TreeSA::surgery_iters` (a library test pins
+this) and additionally exposes the per-round trajectory.
 
 `treewidth` is opt-in per instance because the elimination-order heuristic is
 only meaningful on the structured, low-treewidth instances — running it on a
@@ -124,7 +143,7 @@ random circuit costs time and reports nothing anyone wants to read.
 
 ```json
 {
-  "format": 1,
+  "format": 2,
   "set": "ci",
   "results": [
     {
@@ -134,8 +153,14 @@ random circuit costs time and reports nothing anyone wants to read.
       "sc": 29.0,
       "rwc": 30.808836,
       "curve": [
-        {"round": 0, "score": 3620306748202.0137},
-        {"round": 1, "score": 5525217500107.966}
+        {
+          "round": 0,
+          "tc_before": 38.329681,
+          "tc_after_surgery": 34.087463,
+          "tc_after_anneal": 35.103284,
+          "tc_retained": 34.087463,
+          "surgery_accepted": true
+        }
       ]
     }
   ]
@@ -143,15 +168,13 @@ random circuit costs time and reports nothing anyone wants to read.
 ```
 
 - `tc`, `sc`, `rwc` are `contraction_complexity` in log2 scale.
-- `curve` appears on `treesa_rounds` rows only. It is
-  `RoundsReport::round_scores` — the *trajectory*, not a running minimum, so
-  entries may increase: round `r + 1` continues from round `r`'s tree even when
-  that tree was worse than the incumbent best. That is the escape mechanism the
-  paper is about, and flattening it to a running minimum would hide it. `round`
-  is zero-based, matching `RoundsReport::best_round`. A `curve` entry records
-  that round's *post-anneal* candidate only, while the returned tree may instead
-  be a round's pre-anneal surgery tree — so a row's `tc`/`sc` can be better than
-  every entry in its own `curve`.
+- `curve` appears on `treesa_rounds` rows only. It is the log2 time-complexity
+  trace from `RoundsReport::round_trace`: the retained incumbent before the
+  round, the surgery candidate, the fine-tuning endpoint, and the retained
+  incumbent afterward. `tc_after_anneal` may be worse after fine tuning, but
+  `tc_retained` cannot increase and is the tree used by the next round.
+  `surgery_accepted` marks the rebuild events plotted as crosses in the paper's
+  Figure 2(b).
 - `results` is sorted by `(instance, arm)`, independent of manifest order.
 - `format` is the schema version; bump it when a field's meaning changes, so
   that `check.py` refuses to compare artifacts across the change.
@@ -188,13 +211,8 @@ whether *anything at all* moved.
 
 The tolerance is relative — `abs(a - b) <= max(1e-9, 1e-9 * max(abs(a), abs(b)))`
 — because the fields being compared span twelve orders of magnitude. `tc`, `sc`
-and `rwc` are log2 quantities of order 10, where an absolute `1e-9` is a
-reasonable band. A `curve` score is a raw annealing score, i.e. a weighted sum of
-`2^tc`-scale terms, so on realistic instances it is around `1e12`; there the same
-absolute band would be finer than the spacing between adjacent doubles, and would
-turn "compare across platforms" into "demand bit-exactness". Six-decimal rounding
-is likewise a no-op at that magnitude. Scaling the band with the value keeps one
-rule honest for both.
+and `rwc`, including every `curve` complexity, are log2 quantities of order 10,
+where an absolute `1e-9` is a reasonable band.
 
 ## Manifest policy
 
@@ -209,6 +227,7 @@ Allowed keys:
 - Arm `greedy`: none; `{}` is the only legal value.
 - Arm `treesa`: `ntrials`, `niters`.
 - Arm `treesa_rounds`: `ntrials`, `niters`, `rounds` (required).
+- Arm `treesa_surgery_rule`: `ntrials`, `niters`, `probability` (required).
 - Instance: `name`, `path` (repo-root-relative), `treewidth` (required).
 
 Any other key is a hard error naming the key. Omitted `ntrials`/`niters` mean
@@ -228,9 +247,9 @@ the directory, so an instance nobody declared is never silently benchmarked.
 
 ## Calibration vs the frozen campaign
 
-The full set takes about 21 minutes end to end on an Apple-silicon laptop
-(1266 s for 40 results; the slowest single instance × arm is `nqueens_28`'s
-`treesa_rounds` at 6 minutes).
+The current format-2 full set took 1289.1 s (21.5 minutes) for 40 results on
+the Huawei benchmark host; the slowest single instance × arm was
+`nqueens_28`'s `treesa_rounds` at 220.7 s.
 
 The paper's headline numbers come from a wall-clock-budgeted campaign on a
 fixed host, not from this artifact. It is worth knowing how far apart the two
@@ -241,12 +260,12 @@ rows produced by the `full` set (`TreeSA::default()`, `rounds: 8`).
 
 | Instance | Campaign best tc (huawei, wall-clock budget) | `treesa_rounds` tc (rounds = 8, deterministic) | Gap |
 |---|---|---|---|
-| `surfacecode_d13` | 30.485 — `p4_family["13"]`, the surface-code family sweep: 5 reps at the 90 s budget, both methods tie | 30.898 | +0.413 |
-| `surfacecode_d21` | 47.364 — `p2_budget_scaling`, our TreeSA baseline (`ref`) at the 900 s budget | 49.180 | +1.816 |
-| `ksg` | 36.356 — `p3_distributions`, best of 15 reps at the 90 s budget | 38.291 | +1.935 |
+| `surfacecode_d13` | 30.485 — `p4_family["13"]`, the surface-code family sweep: 5 reps at the 90 s budget, both methods tie | 30.557 | +0.072 |
+| `surfacecode_d21` | 47.364 — `p2_budget_scaling`, our TreeSA baseline (`ref`) at the 900 s budget | 48.395 | +1.031 |
+| `ksg` | 36.356 — `p3_distributions`, best of 15 reps at the 90 s budget | 37.016 | +0.660 |
 
 (The campaign file records `tc` only, so there is no `sc` column to compare;
-this artifact's `sc` for the three rows is 24, 40 and 27 respectively.)
+this artifact's `sc` for the three rows is 24, 40 and 30 respectively.)
 
 The gaps are expected and they are not a defect. The two sides are budgeted by
 different quantities: `rounds` is a *schedule* budget — eight rounds is eight
@@ -256,13 +275,13 @@ A wall-clock budget buys more search on a faster host and less on a slower one,
 which is exactly the property this artifact is built to *not* have. What
 `expected/full.json` claims is bit-reproducibility: run the same commit on the
 same machine and you get the same file. Across machines the claim is weaker and
-partly untested — agreement to `1e-9` is *confirmed* for the `ci` set, which the
-ubuntu CI job re-derives and compares on every push, and *expected* for
-`full.json` by the same mechanism, but nobody has run the full set on a second
-platform. It does not claim to reproduce a record. Raising
-`rounds` in the manifest closes the gap — the rounds loop is the mechanism the
-campaign was exploiting too — at a cost that is proportional and, unlike a
-timer, still deterministic.
+partly untested — agreement to `1e-9` is *confirmed* across the Huawei host and
+Apple silicon for both the `ci` and `figure2b` sets. `full.json` was generated
+on Huawei and is expected to agree by the same mechanism, but its complete
+cross-platform rerun remains unchecked. The eight-round `full` set does not
+claim to reproduce a record. The 32-round `figure2b` set does cross the panel's
+47.824 pre-surgery record at 47.813971 while preserving a fixed work budget;
+it does not claim the campaign's 47.377 median.
 
 ## Frozen campaign data
 

--- a/benchmarks/paper/expected/ci.json
+++ b/benchmarks/paper/expected/ci.json
@@ -1,5 +1,5 @@
 {
-  "format": 1,
+  "format": 2,
   "set": "ci",
   "results": [
     {
@@ -19,17 +19,25 @@
     {
       "instance": "dbn_13",
       "arm": "treesa_rounds",
-      "tc": 32.924983,
-      "sc": 29.0,
-      "rwc": 30.808836,
+      "tc": 30.744297,
+      "sc": 26.0,
+      "rwc": 28.580163,
       "curve": [
         {
           "round": 0,
-          "score": 3620306748202.0137
+          "tc_before": 39.508881,
+          "tc_after_surgery": 36.14333,
+          "tc_after_anneal": 36.952964,
+          "tc_retained": 36.14333,
+          "surgery_accepted": true
         },
         {
           "round": 1,
-          "score": 5525217500107.966
+          "tc_before": 36.14333,
+          "tc_after_surgery": 31.110717,
+          "tc_after_anneal": 31.265409,
+          "tc_retained": 30.744297,
+          "surgery_accepted": true
         }
       ]
     },
@@ -63,11 +71,19 @@
       "curve": [
         {
           "round": 0,
-          "score": 360.0
+          "tc_before": 8.491853,
+          "tc_after_surgery": 8.491853,
+          "tc_after_anneal": 8.491853,
+          "tc_retained": 8.491853,
+          "surgery_accepted": false
         },
         {
           "round": 1,
-          "score": 360.0
+          "tc_before": 8.491853,
+          "tc_after_surgery": 8.491853,
+          "tc_after_anneal": 8.491853,
+          "tc_retained": 8.491853,
+          "surgery_accepted": false
         }
       ]
     },
@@ -95,17 +111,25 @@
     {
       "instance": "qft_27",
       "arm": "treesa_rounds",
-      "tc": 30.198245,
+      "tc": 30.267092,
       "sc": 27.0,
-      "rwc": 29.651725,
+      "rwc": 29.938547,
       "curve": [
         {
           "round": 0,
-          "score": 1849001728.0
+          "tc_before": 30.681567,
+          "tc_after_surgery": 30.267092,
+          "tc_after_anneal": 30.843804,
+          "tc_retained": 30.267092,
+          "surgery_accepted": true
         },
         {
           "round": 1,
-          "score": 1984019360.000002
+          "tc_before": 30.267092,
+          "tc_after_surgery": 30.267092,
+          "tc_after_anneal": 31.336857,
+          "tc_retained": 30.267092,
+          "surgery_accepted": false
         }
       ]
     },
@@ -126,17 +150,25 @@
     {
       "instance": "reg3_250",
       "arm": "treesa_rounds",
-      "tc": 41.40444,
-      "sc": 36.0,
-      "rwc": 39.908527,
+      "tc": 43.197674,
+      "sc": 37.0,
+      "rwc": 41.665937,
       "curve": [
         {
           "round": 0,
-          "score": 105788631234639.47
+          "tc_before": 48.002093,
+          "tc_after_surgery": 43.438224,
+          "tc_after_anneal": 43.291038,
+          "tc_retained": 43.291038,
+          "surgery_accepted": true
         },
         {
           "round": 1,
-          "score": 281821316477065.4
+          "tc_before": 43.291038,
+          "tc_after_surgery": 43.291038,
+          "tc_after_anneal": 43.197674,
+          "tc_retained": 43.197674,
+          "surgery_accepted": false
         }
       ]
     },
@@ -157,17 +189,25 @@
     {
       "instance": "surfacecode_d9",
       "arm": "treesa_rounds",
-      "tc": 21.743061,
+      "tc": 21.742173,
       "sc": 16.0,
-      "rwc": 19.840927,
+      "rwc": 19.866315,
       "curve": [
         {
           "round": 0,
-          "score": 3568206.0
+          "tc_before": 21.739585,
+          "tc_after_surgery": 21.739585,
+          "tc_after_anneal": 21.805338,
+          "tc_retained": 21.738694,
+          "surgery_accepted": false
         },
         {
           "round": 1,
-          "score": 3841510.0
+          "tc_before": 21.738694,
+          "tc_after_surgery": 21.738694,
+          "tc_after_anneal": 21.860719,
+          "tc_retained": 21.738694,
+          "surgery_accepted": false
         }
       ]
     }

--- a/benchmarks/paper/expected/figure2b.json
+++ b/benchmarks/paper/expected/figure2b.json
@@ -1,0 +1,278 @@
+{
+  "format": 2,
+  "set": "figure2b",
+  "results": [
+    {
+      "instance": "surfacecode_d21",
+      "arm": "treesa",
+      "tc": 57.002219,
+      "sc": 40.0,
+      "rwc": 45.789307
+    },
+    {
+      "instance": "surfacecode_d21",
+      "arm": "treesa_rounds",
+      "tc": 47.678726,
+      "sc": 40.0,
+      "rwc": 46.05497,
+      "curve": [
+        {
+          "round": 0,
+          "tc_before": 57.002219,
+          "tc_after_surgery": 49.393878,
+          "tc_after_anneal": 49.117768,
+          "tc_retained": 49.115981,
+          "surgery_accepted": true
+        },
+        {
+          "round": 1,
+          "tc_before": 49.115981,
+          "tc_after_surgery": 49.115981,
+          "tc_after_anneal": 49.122226,
+          "tc_retained": 49.096415,
+          "surgery_accepted": false
+        },
+        {
+          "round": 2,
+          "tc_before": 49.096415,
+          "tc_after_surgery": 49.096415,
+          "tc_after_anneal": 49.098734,
+          "tc_retained": 49.09346,
+          "surgery_accepted": false
+        },
+        {
+          "round": 3,
+          "tc_before": 49.09346,
+          "tc_after_surgery": 49.09346,
+          "tc_after_anneal": 49.093456,
+          "tc_retained": 49.087159,
+          "surgery_accepted": false
+        },
+        {
+          "round": 4,
+          "tc_before": 49.087159,
+          "tc_after_surgery": 49.087159,
+          "tc_after_anneal": 49.11702,
+          "tc_retained": 49.087159,
+          "surgery_accepted": false
+        },
+        {
+          "round": 5,
+          "tc_before": 49.087159,
+          "tc_after_surgery": 49.087159,
+          "tc_after_anneal": 49.099231,
+          "tc_retained": 49.080445,
+          "surgery_accepted": false
+        },
+        {
+          "round": 6,
+          "tc_before": 49.080445,
+          "tc_after_surgery": 49.080445,
+          "tc_after_anneal": 49.090911,
+          "tc_retained": 49.070349,
+          "surgery_accepted": false
+        },
+        {
+          "round": 7,
+          "tc_before": 49.070349,
+          "tc_after_surgery": 49.070349,
+          "tc_after_anneal": 49.076697,
+          "tc_retained": 49.062165,
+          "surgery_accepted": false
+        },
+        {
+          "round": 8,
+          "tc_before": 49.062165,
+          "tc_after_surgery": 49.062165,
+          "tc_after_anneal": 49.056196,
+          "tc_retained": 49.048423,
+          "surgery_accepted": false
+        },
+        {
+          "round": 9,
+          "tc_before": 49.048423,
+          "tc_after_surgery": 49.048423,
+          "tc_after_anneal": 49.098136,
+          "tc_retained": 49.048423,
+          "surgery_accepted": false
+        },
+        {
+          "round": 10,
+          "tc_before": 49.048423,
+          "tc_after_surgery": 49.048423,
+          "tc_after_anneal": 49.045089,
+          "tc_retained": 49.044025,
+          "surgery_accepted": false
+        },
+        {
+          "round": 11,
+          "tc_before": 49.044025,
+          "tc_after_surgery": 48.531859,
+          "tc_after_anneal": 48.237733,
+          "tc_retained": 48.232769,
+          "surgery_accepted": true
+        },
+        {
+          "round": 12,
+          "tc_before": 48.232769,
+          "tc_after_surgery": 48.232769,
+          "tc_after_anneal": 48.18526,
+          "tc_retained": 48.18526,
+          "surgery_accepted": false
+        },
+        {
+          "round": 13,
+          "tc_before": 48.18526,
+          "tc_after_surgery": 48.18526,
+          "tc_after_anneal": 48.178409,
+          "tc_retained": 48.178409,
+          "surgery_accepted": false
+        },
+        {
+          "round": 14,
+          "tc_before": 48.178409,
+          "tc_after_surgery": 48.178409,
+          "tc_after_anneal": 48.166533,
+          "tc_retained": 48.164728,
+          "surgery_accepted": false
+        },
+        {
+          "round": 15,
+          "tc_before": 48.164728,
+          "tc_after_surgery": 47.987115,
+          "tc_after_anneal": 47.973818,
+          "tc_retained": 47.973514,
+          "surgery_accepted": true
+        },
+        {
+          "round": 16,
+          "tc_before": 47.973514,
+          "tc_after_surgery": 47.973514,
+          "tc_after_anneal": 47.967169,
+          "tc_retained": 47.955052,
+          "surgery_accepted": false
+        },
+        {
+          "round": 17,
+          "tc_before": 47.955052,
+          "tc_after_surgery": 47.955052,
+          "tc_after_anneal": 47.939061,
+          "tc_retained": 47.939061,
+          "surgery_accepted": false
+        },
+        {
+          "round": 18,
+          "tc_before": 47.939061,
+          "tc_after_surgery": 47.939061,
+          "tc_after_anneal": 47.902686,
+          "tc_retained": 47.902686,
+          "surgery_accepted": false
+        },
+        {
+          "round": 19,
+          "tc_before": 47.902686,
+          "tc_after_surgery": 47.902686,
+          "tc_after_anneal": 47.916815,
+          "tc_retained": 47.885666,
+          "surgery_accepted": false
+        },
+        {
+          "round": 20,
+          "tc_before": 47.885666,
+          "tc_after_surgery": 47.885666,
+          "tc_after_anneal": 47.888411,
+          "tc_retained": 47.883194,
+          "surgery_accepted": false
+        },
+        {
+          "round": 21,
+          "tc_before": 47.883194,
+          "tc_after_surgery": 47.883194,
+          "tc_after_anneal": 47.856423,
+          "tc_retained": 47.856423,
+          "surgery_accepted": false
+        },
+        {
+          "round": 22,
+          "tc_before": 47.856423,
+          "tc_after_surgery": 47.856423,
+          "tc_after_anneal": 47.94255,
+          "tc_retained": 47.852219,
+          "surgery_accepted": false
+        },
+        {
+          "round": 23,
+          "tc_before": 47.852219,
+          "tc_after_surgery": 47.852219,
+          "tc_after_anneal": 47.838297,
+          "tc_retained": 47.836656,
+          "surgery_accepted": false
+        },
+        {
+          "round": 24,
+          "tc_before": 47.836656,
+          "tc_after_surgery": 47.836656,
+          "tc_after_anneal": 47.82522,
+          "tc_retained": 47.82522,
+          "surgery_accepted": false
+        },
+        {
+          "round": 25,
+          "tc_before": 47.82522,
+          "tc_after_surgery": 47.82522,
+          "tc_after_anneal": 47.825205,
+          "tc_retained": 47.825205,
+          "surgery_accepted": false
+        },
+        {
+          "round": 26,
+          "tc_before": 47.825205,
+          "tc_after_surgery": 47.825205,
+          "tc_after_anneal": 47.799579,
+          "tc_retained": 47.799528,
+          "surgery_accepted": false
+        },
+        {
+          "round": 27,
+          "tc_before": 47.799528,
+          "tc_after_surgery": 47.799528,
+          "tc_after_anneal": 47.72405,
+          "tc_retained": 47.72174,
+          "surgery_accepted": false
+        },
+        {
+          "round": 28,
+          "tc_before": 47.72174,
+          "tc_after_surgery": 47.72174,
+          "tc_after_anneal": 47.798929,
+          "tc_retained": 47.72174,
+          "surgery_accepted": false
+        },
+        {
+          "round": 29,
+          "tc_before": 47.72174,
+          "tc_after_surgery": 47.72174,
+          "tc_after_anneal": 47.797369,
+          "tc_retained": 47.72174,
+          "surgery_accepted": false
+        },
+        {
+          "round": 30,
+          "tc_before": 47.72174,
+          "tc_after_surgery": 47.72174,
+          "tc_after_anneal": 47.778427,
+          "tc_retained": 47.72174,
+          "surgery_accepted": false
+        },
+        {
+          "round": 31,
+          "tc_before": 47.72174,
+          "tc_after_surgery": 47.72174,
+          "tc_after_anneal": 47.721453,
+          "tc_retained": 47.678726,
+          "surgery_accepted": false
+        }
+      ]
+    }
+  ]
+}

--- a/benchmarks/paper/expected/figure2b.svg
+++ b/benchmarks/paper/expected/figure2b.svg
@@ -1,0 +1,88 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="900" height="560" viewBox="0 0 900 560">
+<title>Figure 2(b) reproduction from current main</title>
+<desc>Surface-code distance 21 contraction cost over 32 deterministic surgery and cold fine-tuning rounds. Raw fine-tuning endpoints are separated from the retained incumbent.</desc>
+<rect width="100%" height="100%" fill="white"/>
+<g font-family="Helvetica,Arial,sans-serif" fill="#111">
+<text x="92" y="29" font-size="20" font-weight="700">Figure 2(b) reproduction — current main</text>
+<text x="92" y="52" font-size="13" fill="#444">surfacecode_d21; deterministic 32-round work budget; TreeSA defaults</text>
+<line x1="92" y1="447.34" x2="872" y2="447.34" stroke="#e4e4e4" stroke-width="1"/>
+<text x="80" y="451.34" text-anchor="end" font-size="12">48</text>
+<line x1="92" y1="367.93" x2="872" y2="367.93" stroke="#e4e4e4" stroke-width="1"/>
+<text x="80" y="371.93" text-anchor="end" font-size="12">50</text>
+<line x1="92" y1="288.51" x2="872" y2="288.51" stroke="#e4e4e4" stroke-width="1"/>
+<text x="80" y="292.51" text-anchor="end" font-size="12">52</text>
+<line x1="92" y1="209.10" x2="872" y2="209.10" stroke="#e4e4e4" stroke-width="1"/>
+<text x="80" y="213.10" text-anchor="end" font-size="12">54</text>
+<line x1="92" y1="129.69" x2="872" y2="129.69" stroke="#e4e4e4" stroke-width="1"/>
+<text x="80" y="133.69" text-anchor="end" font-size="12">56</text>
+<line x1="92.00" y1="76" x2="92.00" y2="482" stroke="#f0f0f0" stroke-width="1"/>
+<text x="92.00" y="505" text-anchor="middle" font-size="12">0</text>
+<line x1="189.50" y1="76" x2="189.50" y2="482" stroke="#f0f0f0" stroke-width="1"/>
+<text x="189.50" y="505" text-anchor="middle" font-size="12">4</text>
+<line x1="287.00" y1="76" x2="287.00" y2="482" stroke="#f0f0f0" stroke-width="1"/>
+<text x="287.00" y="505" text-anchor="middle" font-size="12">8</text>
+<line x1="384.50" y1="76" x2="384.50" y2="482" stroke="#f0f0f0" stroke-width="1"/>
+<text x="384.50" y="505" text-anchor="middle" font-size="12">12</text>
+<line x1="482.00" y1="76" x2="482.00" y2="482" stroke="#f0f0f0" stroke-width="1"/>
+<text x="482.00" y="505" text-anchor="middle" font-size="12">16</text>
+<line x1="579.50" y1="76" x2="579.50" y2="482" stroke="#f0f0f0" stroke-width="1"/>
+<text x="579.50" y="505" text-anchor="middle" font-size="12">20</text>
+<line x1="677.00" y1="76" x2="677.00" y2="482" stroke="#f0f0f0" stroke-width="1"/>
+<text x="677.00" y="505" text-anchor="middle" font-size="12">24</text>
+<line x1="774.50" y1="76" x2="774.50" y2="482" stroke="#f0f0f0" stroke-width="1"/>
+<text x="774.50" y="505" text-anchor="middle" font-size="12">28</text>
+<line x1="872.00" y1="76" x2="872.00" y2="482" stroke="#f0f0f0" stroke-width="1"/>
+<text x="872.00" y="505" text-anchor="middle" font-size="12">32</text>
+<line x1="92" y1="76" x2="92" y2="482" stroke="#111" stroke-width="1.4"/>
+<line x1="92" y1="482" x2="872" y2="482" stroke="#111" stroke-width="1.4"/>
+<text x="482.00" y="536" text-anchor="middle" font-size="14">completed surgery/fine-tuning rounds</text>
+<text x="23" y="279.00" text-anchor="middle" font-size="14" transform="rotate(-90 23 279.00)">contraction cost tc  [log₂ flops]</text>
+<line x1="92" y1="454.33" x2="872" y2="454.33" stroke="#222" stroke-width="1.5" stroke-dasharray="3 5"/>
+<line x1="92" y1="472.07" x2="872" y2="472.07" stroke="#cc3311" stroke-width="1.5" stroke-dasharray="9 4 2 4"/>
+<polyline points="92.00,89.90 116.38,403.03 140.75,403.80 165.12,403.92 189.50,404.17 213.88,404.17 238.25,404.44 262.62,404.84 287.00,405.16 311.38,405.71 335.75,405.71 360.12,405.88 384.50,438.09 408.88,439.98 433.25,440.25 457.62,440.80 482.00,448.39 506.38,449.12 530.75,449.76 555.12,451.20 579.50,451.88 603.88,451.97 628.25,453.04 652.62,453.20 677.00,453.82 701.38,454.28 725.75,454.28 750.12,455.30 774.50,458.39 798.88,458.39 823.25,458.39 847.62,458.39 872.00,460.09" fill="none" stroke="#0072b2" stroke-width="2.8" stroke-linejoin="round" stroke-linecap="round"/>
+<circle cx="116.38" cy="402.96" r="3.1" fill="white" stroke="#777" stroke-width="1.3"/>
+<line x1="111.38" y1="386.99" x2="121.38" y2="396.99" stroke="#cc3311" stroke-width="2.2"/>
+<line x1="111.38" y1="396.99" x2="121.38" y2="386.99" stroke="#cc3311" stroke-width="2.2"/>
+<circle cx="140.75" cy="402.78" r="3.1" fill="white" stroke="#777" stroke-width="1.3"/>
+<circle cx="165.12" cy="403.71" r="3.1" fill="white" stroke="#777" stroke-width="1.3"/>
+<circle cx="189.50" cy="403.92" r="3.1" fill="white" stroke="#777" stroke-width="1.3"/>
+<circle cx="213.88" cy="402.98" r="3.1" fill="white" stroke="#777" stroke-width="1.3"/>
+<circle cx="238.25" cy="403.69" r="3.1" fill="white" stroke="#777" stroke-width="1.3"/>
+<circle cx="262.62" cy="404.02" r="3.1" fill="white" stroke="#777" stroke-width="1.3"/>
+<circle cx="287.00" cy="404.59" r="3.1" fill="white" stroke="#777" stroke-width="1.3"/>
+<circle cx="311.38" cy="405.40" r="3.1" fill="white" stroke="#777" stroke-width="1.3"/>
+<circle cx="335.75" cy="403.73" r="3.1" fill="white" stroke="#777" stroke-width="1.3"/>
+<circle cx="360.12" cy="405.84" r="3.1" fill="white" stroke="#777" stroke-width="1.3"/>
+<circle cx="384.50" cy="437.90" r="3.1" fill="white" stroke="#777" stroke-width="1.3"/>
+<line x1="379.50" y1="421.22" x2="389.50" y2="431.22" stroke="#cc3311" stroke-width="2.2"/>
+<line x1="379.50" y1="431.22" x2="389.50" y2="421.22" stroke="#cc3311" stroke-width="2.2"/>
+<circle cx="408.88" cy="439.98" r="3.1" fill="white" stroke="#777" stroke-width="1.3"/>
+<circle cx="433.25" cy="440.25" r="3.1" fill="white" stroke="#777" stroke-width="1.3"/>
+<circle cx="457.62" cy="440.72" r="3.1" fill="white" stroke="#777" stroke-width="1.3"/>
+<circle cx="482.00" cy="448.38" r="3.1" fill="white" stroke="#777" stroke-width="1.3"/>
+<line x1="477.00" y1="442.85" x2="487.00" y2="452.85" stroke="#cc3311" stroke-width="2.2"/>
+<line x1="477.00" y1="452.85" x2="487.00" y2="442.85" stroke="#cc3311" stroke-width="2.2"/>
+<circle cx="506.38" cy="448.64" r="3.1" fill="white" stroke="#777" stroke-width="1.3"/>
+<circle cx="530.75" cy="449.76" r="3.1" fill="white" stroke="#777" stroke-width="1.3"/>
+<circle cx="555.12" cy="451.20" r="3.1" fill="white" stroke="#777" stroke-width="1.3"/>
+<circle cx="579.50" cy="450.64" r="3.1" fill="white" stroke="#777" stroke-width="1.3"/>
+<circle cx="603.88" cy="451.77" r="3.1" fill="white" stroke="#777" stroke-width="1.3"/>
+<circle cx="628.25" cy="453.04" r="3.1" fill="white" stroke="#777" stroke-width="1.3"/>
+<circle cx="652.62" cy="449.62" r="3.1" fill="white" stroke="#777" stroke-width="1.3"/>
+<circle cx="677.00" cy="453.76" r="3.1" fill="white" stroke="#777" stroke-width="1.3"/>
+<circle cx="701.38" cy="454.28" r="3.1" fill="white" stroke="#777" stroke-width="1.3"/>
+<circle cx="725.75" cy="454.28" r="3.1" fill="white" stroke="#777" stroke-width="1.3"/>
+<circle cx="750.12" cy="455.29" r="3.1" fill="white" stroke="#777" stroke-width="1.3"/>
+<circle cx="774.50" cy="458.29" r="3.1" fill="white" stroke="#777" stroke-width="1.3"/>
+<circle cx="798.88" cy="455.32" r="3.1" fill="white" stroke="#777" stroke-width="1.3"/>
+<circle cx="823.25" cy="455.38" r="3.1" fill="white" stroke="#777" stroke-width="1.3"/>
+<circle cx="847.62" cy="456.13" r="3.1" fill="white" stroke="#777" stroke-width="1.3"/>
+<circle cx="872.00" cy="458.40" r="3.1" fill="white" stroke="#777" stroke-width="1.3"/>
+<rect x="508" y="73" width="360" height="105" fill="white" fill-opacity="0.92" stroke="#bbb"/>
+<line x1="520" y1="91" x2="548" y2="91" stroke="#0072b2" stroke-width="2.8"/><text x="558" y="95" font-size="12">retained incumbent</text>
+<circle cx="534" cy="113" r="3.1" fill="white" stroke="#777" stroke-width="1.3"/><text x="558" y="117" font-size="12">raw fine-tuning endpoint</text>
+<path d="M 529 130 l 10 10 m -10 0 l 10 -10" stroke="#cc3311" stroke-width="2.2"/><text x="558" y="139" font-size="12">accepted waist rebuild</text>
+<line x1="520" y1="157" x2="548" y2="157" stroke="#222" stroke-width="1.5" stroke-dasharray="3 5"/><text x="558" y="161" font-size="12">pre-surgery record 47.824</text>
+<line x1="710" y1="157" x2="738" y2="157" stroke="#cc3311" stroke-width="1.5" stroke-dasharray="9 4 2 4"/><text x="748" y="161" font-size="12">official median 47.377</text>
+<text x="92" y="555" font-size="10" fill="#555">Source: figure2b.json; final retained tc = 47.678726</text>
+</g></svg>

--- a/benchmarks/paper/expected/full.json
+++ b/benchmarks/paper/expected/full.json
@@ -1,5 +1,5 @@
 {
-  "format": 1,
+  "format": 2,
   "set": "full",
   "results": [
     {
@@ -19,41 +19,73 @@
     {
       "instance": "dbn_13",
       "arm": "treesa_rounds",
-      "tc": 31.626773,
-      "sc": 27.0,
-      "rwc": 29.98394,
+      "tc": 30.602745,
+      "sc": 25.0,
+      "rwc": 27.989262,
       "curve": [
         {
           "round": 0,
-          "score": 3620306748202.0137
+          "tc_before": 39.508881,
+          "tc_after_surgery": 36.14333,
+          "tc_after_anneal": 36.952964,
+          "tc_retained": 36.14333,
+          "surgery_accepted": true
         },
         {
           "round": 1,
-          "score": 5525217500107.966
+          "tc_before": 36.14333,
+          "tc_after_surgery": 31.110717,
+          "tc_after_anneal": 31.265409,
+          "tc_retained": 30.744297,
+          "surgery_accepted": true
         },
         {
           "round": 2,
-          "score": 6724778164522.047
+          "tc_before": 30.744297,
+          "tc_after_surgery": 30.744297,
+          "tc_after_anneal": 30.720022,
+          "tc_retained": 30.606706,
+          "surgery_accepted": false
         },
         {
           "round": 3,
-          "score": 2293312584679.999
+          "tc_before": 30.606706,
+          "tc_after_surgery": 30.606706,
+          "tc_after_anneal": 31.515637,
+          "tc_retained": 30.606706,
+          "surgery_accepted": false
         },
         {
           "round": 4,
-          "score": 5899952127222.0625
+          "tc_before": 30.606706,
+          "tc_after_surgery": 30.606706,
+          "tc_after_anneal": 30.773194,
+          "tc_retained": 30.602745,
+          "surgery_accepted": false
         },
         {
           "round": 5,
-          "score": 7185213670945.991
+          "tc_before": 30.602745,
+          "tc_after_surgery": 30.602745,
+          "tc_after_anneal": 30.73799,
+          "tc_retained": 30.602745,
+          "surgery_accepted": false
         },
         {
           "round": 6,
-          "score": 1097338782805.9968
+          "tc_before": 30.602745,
+          "tc_after_surgery": 30.602745,
+          "tc_after_anneal": 30.877169,
+          "tc_retained": 30.602745,
+          "surgery_accepted": false
         },
         {
           "round": 7,
-          "score": 2737974462945.9824
+          "tc_before": 30.602745,
+          "tc_after_surgery": 30.602745,
+          "tc_after_anneal": 31.440019,
+          "tc_retained": 30.602745,
+          "surgery_accepted": false
         }
       ]
     },
@@ -81,41 +113,73 @@
     {
       "instance": "ksg",
       "arm": "treesa_rounds",
-      "tc": 38.29143,
-      "sc": 27.0,
-      "rwc": 31.154449,
+      "tc": 37.015153,
+      "sc": 29.0,
+      "rwc": 34.192211,
       "curve": [
         {
           "round": 0,
-          "score": 863142252796.0095
+          "tc_before": 38.769071,
+          "tc_after_surgery": 38.172066,
+          "tc_after_anneal": 37.625317,
+          "tc_retained": 37.574414,
+          "surgery_accepted": true
         },
         {
           "round": 1,
-          "score": 852462146564.0146
+          "tc_before": 37.574414,
+          "tc_after_surgery": 37.574414,
+          "tc_after_anneal": 37.50573,
+          "tc_retained": 37.50573,
+          "surgery_accepted": false
         },
         {
           "round": 2,
-          "score": 37585703662715.76
+          "tc_before": 37.50573,
+          "tc_after_surgery": 37.50573,
+          "tc_after_anneal": 37.462542,
+          "tc_retained": 37.389794,
+          "surgery_accepted": false
         },
         {
           "round": 3,
-          "score": 1753717561335.9976
+          "tc_before": 37.389794,
+          "tc_after_surgery": 37.389794,
+          "tc_after_anneal": 37.150513,
+          "tc_retained": 37.141121,
+          "surgery_accepted": false
         },
         {
           "round": 4,
-          "score": 1226077470931.9983
+          "tc_before": 37.141121,
+          "tc_after_surgery": 37.141121,
+          "tc_after_anneal": 37.370707,
+          "tc_retained": 37.110124,
+          "surgery_accepted": false
         },
         {
           "round": 5,
-          "score": 475956095632.0011
+          "tc_before": 37.110124,
+          "tc_after_surgery": 37.110124,
+          "tc_after_anneal": 37.167811,
+          "tc_retained": 37.101503,
+          "surgery_accepted": false
         },
         {
           "round": 6,
-          "score": 336543370360.001
+          "tc_before": 37.101503,
+          "tc_after_surgery": 37.101503,
+          "tc_after_anneal": 37.401511,
+          "tc_retained": 37.085884,
+          "surgery_accepted": false
         },
         {
           "round": 7,
-          "score": 615890430784.0006
+          "tc_before": 37.085884,
+          "tc_after_surgery": 37.085884,
+          "tc_after_anneal": 37.015153,
+          "tc_retained": 37.015153,
+          "surgery_accepted": false
         }
       ]
     },
@@ -136,41 +200,73 @@
     {
       "instance": "nqueens_28",
       "arm": "treesa_rounds",
-      "tc": 128.33985,
-      "sc": 86.0,
-      "rwc": 91.887892,
+      "tc": 124.044394,
+      "sc": 89.0,
+      "rwc": 94.839266,
       "curve": [
         {
           "round": 0,
-          "score": 6.96990009378416e+41
+          "tc_before": 128.33985,
+          "tc_after_surgery": 128.33985,
+          "tc_after_anneal": 124.087463,
+          "tc_retained": 124.087463,
+          "surgery_accepted": false
         },
         {
           "round": 1,
-          "score": 2.4519975421906987e+55
+          "tc_before": 124.087463,
+          "tc_after_surgery": 124.087463,
+          "tc_after_anneal": 125.044394,
+          "tc_retained": 124.087463,
+          "surgery_accepted": false
         },
         {
           "round": 2,
-          "score": 5.868842534248737e+48
+          "tc_before": 124.087463,
+          "tc_after_surgery": 124.087463,
+          "tc_after_anneal": 124.087463,
+          "tc_retained": 124.087463,
+          "surgery_accepted": false
         },
         {
           "round": 3,
-          "score": 1.8398115387980034e+44
+          "tc_before": 124.087463,
+          "tc_after_surgery": 124.087463,
+          "tc_after_anneal": 124.087463,
+          "tc_retained": 124.044394,
+          "surgery_accepted": false
         },
         {
           "round": 4,
-          "score": 2.180040252202551e+41
+          "tc_before": 124.044394,
+          "tc_after_surgery": 124.044394,
+          "tc_after_anneal": 124.044394,
+          "tc_retained": 124.044394,
+          "surgery_accepted": false
         },
         {
           "round": 5,
-          "score": 3.568555750240457e+44
+          "tc_before": 124.044394,
+          "tc_after_surgery": 124.044394,
+          "tc_after_anneal": 124.044394,
+          "tc_retained": 124.044394,
+          "surgery_accepted": false
         },
         {
           "round": 6,
-          "score": 3.4913054087372734e+41
+          "tc_before": 124.044394,
+          "tc_after_surgery": 124.044394,
+          "tc_after_anneal": 124.044394,
+          "tc_retained": 124.044394,
+          "surgery_accepted": false
         },
         {
           "round": 7,
-          "score": 8.166880733819522e+39
+          "tc_before": 124.044394,
+          "tc_after_surgery": 124.044394,
+          "tc_after_anneal": 124.087463,
+          "tc_retained": 124.044394,
+          "surgery_accepted": false
         }
       ]
     },
@@ -191,41 +287,73 @@
     {
       "instance": "qft_27",
       "arm": "treesa_rounds",
-      "tc": 30.198245,
+      "tc": 30.091205,
       "sc": 27.0,
-      "rwc": 29.651725,
+      "rwc": 29.439528,
       "curve": [
         {
           "round": 0,
-          "score": 1849001728.0
+          "tc_before": 30.584279,
+          "tc_after_surgery": 30.267092,
+          "tc_after_anneal": 30.843804,
+          "tc_retained": 30.267092,
+          "surgery_accepted": true
         },
         {
           "round": 1,
-          "score": 1984019360.000002
+          "tc_before": 30.267092,
+          "tc_after_surgery": 30.267092,
+          "tc_after_anneal": 31.336857,
+          "tc_retained": 30.267092,
+          "surgery_accepted": false
         },
         {
           "round": 2,
-          "score": 1729847408.000001
+          "tc_before": 30.267092,
+          "tc_after_surgery": 30.091271,
+          "tc_after_anneal": 30.842801,
+          "tc_retained": 30.091271,
+          "surgery_accepted": true
         },
         {
           "round": 3,
-          "score": 2224607287.999998
+          "tc_before": 30.091271,
+          "tc_after_surgery": 30.091271,
+          "tc_after_anneal": 30.879635,
+          "tc_retained": 30.091271,
+          "surgery_accepted": false
         },
         {
           "round": 4,
-          "score": 2124102632.000001
+          "tc_before": 30.091271,
+          "tc_after_surgery": 30.091271,
+          "tc_after_anneal": 30.628187,
+          "tc_retained": 30.091271,
+          "surgery_accepted": false
         },
         {
           "round": 5,
-          "score": 2304939840.000002
+          "tc_before": 30.091271,
+          "tc_after_surgery": 30.091271,
+          "tc_after_anneal": 30.682603,
+          "tc_retained": 30.091271,
+          "surgery_accepted": false
         },
         {
           "round": 6,
-          "score": 2395931063.999998
+          "tc_before": 30.091271,
+          "tc_after_surgery": 30.091271,
+          "tc_after_anneal": 30.393185,
+          "tc_retained": 30.091271,
+          "surgery_accepted": false
         },
         {
           "round": 7,
-          "score": 1863529184.0
+          "tc_before": 30.091271,
+          "tc_after_surgery": 30.091271,
+          "tc_after_anneal": 30.198464,
+          "tc_retained": 30.091205,
+          "surgery_accepted": false
         }
       ]
     },
@@ -246,41 +374,73 @@
     {
       "instance": "reg3_1000",
       "arm": "treesa_rounds",
-      "tc": 147.506289,
-      "sc": 141.0,
-      "rwc": 145.985226,
+      "tc": 145.414281,
+      "sc": 138.0,
+      "rwc": 143.875169,
       "curve": [
         {
           "round": 0,
-          "score": 1.004336277661876e+59
+          "tc_before": 196.0,
+          "tc_after_surgery": 185.000002,
+          "tc_after_anneal": 161.329725,
+          "tc_retained": 161.329725,
+          "surgery_accepted": true
         },
         {
           "round": 1,
-          "score": 4.017467710290745e+59
+          "tc_before": 161.329725,
+          "tc_after_surgery": 157.234461,
+          "tc_after_anneal": 150.12978,
+          "tc_retained": 150.12978,
+          "surgery_accepted": true
         },
         {
           "round": 2,
-          "score": 1.5692756209188728e+57
+          "tc_before": 150.12978,
+          "tc_after_surgery": 150.12978,
+          "tc_after_anneal": 147.488775,
+          "tc_retained": 147.488775,
+          "surgery_accepted": false
         },
         {
           "round": 3,
-          "score": 1.2955937981838166e+61
+          "tc_before": 147.488775,
+          "tc_after_surgery": 147.488775,
+          "tc_after_anneal": 145.940173,
+          "tc_retained": 145.940173,
+          "surgery_accepted": false
         },
         {
           "round": 4,
-          "score": 1.606939576754545e+60
+          "tc_before": 145.940173,
+          "tc_after_surgery": 145.940173,
+          "tc_after_anneal": 145.763341,
+          "tc_retained": 145.763341,
+          "surgery_accepted": false
         },
         {
           "round": 5,
-          "score": 3.927019823475655e+56
+          "tc_before": 145.763341,
+          "tc_after_surgery": 145.763341,
+          "tc_after_anneal": 145.491128,
+          "tc_retained": 145.483087,
+          "surgery_accepted": false
         },
         {
           "round": 6,
-          "score": 4.017348941886363e+59
+          "tc_before": 145.483087,
+          "tc_after_surgery": 145.483087,
+          "tc_after_anneal": 145.444888,
+          "tc_retained": 145.444888,
+          "surgery_accepted": false
         },
         {
           "round": 7,
-          "score": 7.663413065377595e+53
+          "tc_before": 145.444888,
+          "tc_after_surgery": 145.444888,
+          "tc_after_anneal": 145.414281,
+          "tc_retained": 145.414281,
+          "surgery_accepted": false
         }
       ]
     },
@@ -301,41 +461,73 @@
     {
       "instance": "reg3_250",
       "arm": "treesa_rounds",
-      "tc": 41.097707,
-      "sc": 35.0,
-      "rwc": 39.33346,
+      "tc": 40.586136,
+      "sc": 34.0,
+      "rwc": 38.729941,
       "curve": [
         {
           "round": 0,
-          "score": 563716742396371.0
+          "tc_before": 45.336815,
+          "tc_after_surgery": 41.658727,
+          "tc_after_anneal": 41.02221,
+          "tc_retained": 41.02221,
+          "surgery_accepted": true
         },
         {
           "round": 1,
-          "score": 1126733376781451.0
+          "tc_before": 41.02221,
+          "tc_after_surgery": 40.716728,
+          "tc_after_anneal": 40.765515,
+          "tc_retained": 40.660791,
+          "surgery_accepted": true
         },
         {
           "round": 2,
-          "score": 2252945307299281.0
+          "tc_before": 40.660791,
+          "tc_after_surgery": 40.660791,
+          "tc_after_anneal": 40.830301,
+          "tc_retained": 40.660791,
+          "surgery_accepted": false
         },
         {
           "round": 3,
-          "score": 281825683797872.75
+          "tc_before": 40.660791,
+          "tc_after_surgery": 40.660791,
+          "tc_after_anneal": 40.594219,
+          "tc_retained": 40.594219,
+          "surgery_accepted": false
         },
         {
           "round": 4,
-          "score": 282765926801040.4
+          "tc_before": 40.594219,
+          "tc_after_surgery": 40.594219,
+          "tc_after_anneal": 40.687511,
+          "tc_retained": 40.586136,
+          "surgery_accepted": false
         },
         {
           "round": 5,
-          "score": 844869743696684.5
+          "tc_before": 40.586136,
+          "tc_after_surgery": 40.586136,
+          "tc_after_anneal": 40.79496,
+          "tc_retained": 40.586136,
+          "surgery_accepted": false
         },
         {
           "round": 6,
-          "score": 281903460555849.5
+          "tc_before": 40.586136,
+          "tc_after_surgery": 40.586136,
+          "tc_after_anneal": 40.638933,
+          "tc_retained": 40.586136,
+          "surgery_accepted": false
         },
         {
           "round": 7,
-          "score": 564027983496692.6
+          "tc_before": 40.586136,
+          "tc_after_surgery": 40.586136,
+          "tc_after_anneal": 40.739899,
+          "tc_retained": 40.586136,
+          "surgery_accepted": false
         }
       ]
     },
@@ -356,41 +548,73 @@
     {
       "instance": "rqc_97_m24",
       "arm": "treesa_rounds",
-      "tc": 107.22908,
+      "tc": 107.503109,
       "sc": 97.0,
-      "rwc": 106.074865,
+      "rwc": 106.407588,
       "curve": [
         {
           "round": 0,
-          "score": 1.742259012563107e+41
+          "tc_before": 131.247928,
+          "tc_after_surgery": 131.247928,
+          "tc_after_anneal": 123.584974,
+          "tc_retained": 123.584969,
+          "surgery_accepted": false
         },
         {
           "round": 1,
-          "score": 2.787848361591788e+42
+          "tc_before": 123.584969,
+          "tc_after_surgery": 123.584969,
+          "tc_after_anneal": 123.584981,
+          "tc_retained": 123.584969,
+          "surgery_accepted": false
         },
         {
           "round": 2,
-          "score": 8.711232752599886e+40
+          "tc_before": 123.584969,
+          "tc_after_surgery": 120.087566,
+          "tc_after_anneal": 119.022621,
+          "tc_retained": 119.022621,
+          "surgery_accepted": true
         },
         {
           "round": 3,
-          "score": 1.1150542741132078e+43
+          "tc_before": 119.022621,
+          "tc_after_surgery": 119.022621,
+          "tc_after_anneal": 117.003051,
+          "tc_retained": 117.002705,
+          "surgery_accepted": false
         },
         {
           "round": 4,
-          "score": 2.2300830269311753e+43
+          "tc_before": 117.002705,
+          "tc_after_surgery": 108.217839,
+          "tc_after_anneal": 107.578613,
+          "tc_retained": 107.578613,
+          "surgery_accepted": true
         },
         {
           "round": 5,
-          "score": 2.194821272934161e+40
+          "tc_before": 107.578613,
+          "tc_after_surgery": 107.578613,
+          "tc_after_anneal": 107.540393,
+          "tc_retained": 107.540392,
+          "surgery_accepted": false
         },
         {
           "round": 6,
-          "score": 2.2300830269146563e+43
+          "tc_before": 107.540392,
+          "tc_after_surgery": 107.540392,
+          "tc_after_anneal": 107.50456,
+          "tc_retained": 107.50456,
+          "surgery_accepted": false
         },
         {
           "round": 7,
-          "score": 2.2300745364719493e+43
+          "tc_before": 107.50456,
+          "tc_after_surgery": 107.50456,
+          "tc_after_anneal": 107.503109,
+          "tc_retained": 107.503109,
+          "surgery_accepted": false
         }
       ]
     },
@@ -411,41 +635,73 @@
     {
       "instance": "surfacecode_d13",
       "arm": "treesa_rounds",
-      "tc": 30.898011,
+      "tc": 30.644298,
       "sc": 24.0,
-      "rwc": 28.612004,
+      "rwc": 28.660212,
       "curve": [
         {
           "round": 0,
-          "score": 35278799370.00019
+          "tc_before": 31.791639,
+          "tc_after_surgery": 31.284857,
+          "tc_after_anneal": 31.281734,
+          "tc_retained": 31.20468,
+          "surgery_accepted": true
         },
         {
           "round": 1,
-          "score": 35708916169.99954
+          "tc_before": 31.20468,
+          "tc_after_surgery": 31.20468,
+          "tc_after_anneal": 31.37532,
+          "tc_retained": 31.151457,
+          "surgery_accepted": false
         },
         {
           "round": 2,
-          "score": 35255645205.999954
+          "tc_before": 31.151457,
+          "tc_after_surgery": 30.766924,
+          "tc_after_anneal": 30.766311,
+          "tc_retained": 30.766311,
+          "surgery_accepted": true
         },
         {
           "round": 3,
-          "score": 11632362481.999994
+          "tc_before": 30.766311,
+          "tc_after_surgery": 30.766311,
+          "tc_after_anneal": 30.690407,
+          "tc_retained": 30.690407,
+          "surgery_accepted": false
         },
         {
           "round": 4,
-          "score": 35658295678.0006
+          "tc_before": 30.690407,
+          "tc_after_surgery": 30.690407,
+          "tc_after_anneal": 30.708168,
+          "tc_retained": 30.687559,
+          "surgery_accepted": false
         },
         {
           "round": 5,
-          "score": 22724424546.00002
+          "tc_before": 30.687559,
+          "tc_after_surgery": 30.687559,
+          "tc_after_anneal": 30.777632,
+          "tc_retained": 30.671499,
+          "surgery_accepted": false
         },
         {
           "round": 6,
-          "score": 5722694321.999926
+          "tc_before": 30.671499,
+          "tc_after_surgery": 30.671499,
+          "tc_after_anneal": 30.850138,
+          "tc_retained": 30.671174,
+          "surgery_accepted": false
         },
         {
           "round": 7,
-          "score": 2016640758.000002
+          "tc_before": 30.671174,
+          "tc_after_surgery": 30.644283,
+          "tc_after_anneal": 30.79662,
+          "tc_retained": 30.644283,
+          "surgery_accepted": true
         }
       ]
     },
@@ -466,41 +722,73 @@
     {
       "instance": "surfacecode_d17",
       "arm": "treesa_rounds",
-      "tc": 39.634811,
+      "tc": 39.178517,
       "sc": 32.0,
-      "rwc": 38.087144,
+      "rwc": 37.686153,
       "curve": [
         {
           "round": 0,
-          "score": 75210050052206.0
+          "tc_before": 42.264702,
+          "tc_after_surgery": 39.742466,
+          "tc_after_anneal": 39.800575,
+          "tc_retained": 39.741571,
+          "surgery_accepted": true
         },
         {
           "round": 1,
-          "score": 35709971970546.1
+          "tc_before": 39.741571,
+          "tc_after_surgery": 39.741571,
+          "tc_after_anneal": 39.800503,
+          "tc_retained": 39.741571,
+          "surgery_accepted": false
         },
         {
           "round": 2,
-          "score": 35766116736146.09
+          "tc_before": 39.741571,
+          "tc_after_surgery": 39.684997,
+          "tc_after_anneal": 40.200411,
+          "tc_retained": 39.608125,
+          "surgery_accepted": true
         },
         {
           "round": 3,
-          "score": 72098489496841.98
+          "tc_before": 39.608125,
+          "tc_after_surgery": 39.608125,
+          "tc_after_anneal": 39.59445,
+          "tc_retained": 39.549411,
+          "surgery_accepted": false
         },
         {
           "round": 4,
-          "score": 20298685374785.727
+          "tc_before": 39.549411,
+          "tc_after_surgery": 39.549411,
+          "tc_after_anneal": 39.605667,
+          "tc_retained": 39.529583,
+          "surgery_accepted": false
         },
         {
           "round": 5,
-          "score": 35702037793585.914
+          "tc_before": 39.529583,
+          "tc_after_surgery": 39.399806,
+          "tc_after_anneal": 39.286813,
+          "tc_retained": 39.286813,
+          "surgery_accepted": true
         },
         {
           "round": 6,
-          "score": 35719417867646.23
+          "tc_before": 39.286813,
+          "tc_after_surgery": 39.286813,
+          "tc_after_anneal": 39.274426,
+          "tc_retained": 39.258019,
+          "surgery_accepted": false
         },
         {
           "round": 7,
-          "score": 9697151196373.984
+          "tc_before": 39.258019,
+          "tc_after_surgery": 39.258019,
+          "tc_after_anneal": 39.178517,
+          "tc_retained": 39.178517,
+          "surgery_accepted": false
         }
       ]
     },
@@ -521,41 +809,73 @@
     {
       "instance": "surfacecode_d21",
       "arm": "treesa_rounds",
-      "tc": 49.180267,
+      "tc": 49.062165,
       "sc": 40.0,
-      "rwc": 47.79482,
+      "rwc": 47.890606,
       "curve": [
         {
           "round": 0,
-          "score": 5.813032788970935e+17
+          "tc_before": 57.002219,
+          "tc_after_surgery": 49.393878,
+          "tc_after_anneal": 49.117768,
+          "tc_retained": 49.115981,
+          "surgery_accepted": true
         },
         {
           "round": 1,
-          "score": 3.065215033183559e+17
+          "tc_before": 49.115981,
+          "tc_after_surgery": 49.115981,
+          "tc_after_anneal": 49.122226,
+          "tc_retained": 49.096415,
+          "surgery_accepted": false
         },
         {
           "round": 2,
-          "score": 1.4471145045576992e+17
+          "tc_before": 49.096415,
+          "tc_after_surgery": 49.096415,
+          "tc_after_anneal": 49.098734,
+          "tc_retained": 49.09346,
+          "surgery_accepted": false
         },
         {
           "round": 3,
-          "score": 1.4487216980675024e+17
+          "tc_before": 49.09346,
+          "tc_after_surgery": 49.09346,
+          "tc_after_anneal": 49.093456,
+          "tc_retained": 49.087159,
+          "surgery_accepted": false
         },
         {
           "round": 4,
-          "score": 1.444930031123393e+17
+          "tc_before": 49.087159,
+          "tc_after_surgery": 49.087159,
+          "tc_after_anneal": 49.11702,
+          "tc_retained": 49.087159,
+          "surgery_accepted": false
         },
         {
           "round": 5,
-          "score": 7.24887943975884e+16
+          "tc_before": 49.087159,
+          "tc_after_surgery": 49.087159,
+          "tc_after_anneal": 49.099231,
+          "tc_retained": 49.080445,
+          "surgery_accepted": false
         },
         {
           "round": 6,
-          "score": 5.7784297119029e+17
+          "tc_before": 49.080445,
+          "tc_after_surgery": 49.080445,
+          "tc_after_anneal": 49.090911,
+          "tc_retained": 49.070349,
+          "surgery_accepted": false
         },
         {
           "round": 7,
-          "score": 5.777904495887715e+17
+          "tc_before": 49.070349,
+          "tc_after_surgery": 49.070349,
+          "tc_after_anneal": 49.076697,
+          "tc_retained": 49.062165,
+          "surgery_accepted": false
         }
       ]
     },
@@ -576,41 +896,73 @@
     {
       "instance": "surfacecode_d9",
       "arm": "treesa_rounds",
-      "tc": 21.743061,
+      "tc": 21.742173,
       "sc": 16.0,
-      "rwc": 19.840927,
+      "rwc": 19.866315,
       "curve": [
         {
           "round": 0,
-          "score": 3568206.0
+          "tc_before": 21.739585,
+          "tc_after_surgery": 21.739585,
+          "tc_after_anneal": 21.805338,
+          "tc_retained": 21.738694,
+          "surgery_accepted": false
         },
         {
           "round": 1,
-          "score": 3841510.0
+          "tc_before": 21.738694,
+          "tc_after_surgery": 21.738694,
+          "tc_after_anneal": 21.860719,
+          "tc_retained": 21.738694,
+          "surgery_accepted": false
         },
         {
           "round": 2,
-          "score": 3571174.0
+          "tc_before": 21.738694,
+          "tc_after_surgery": 21.738694,
+          "tc_after_anneal": 21.751506,
+          "tc_retained": 21.738694,
+          "surgery_accepted": false
         },
         {
           "round": 3,
-          "score": 3989362.0
+          "tc_before": 21.738694,
+          "tc_after_surgery": 21.738694,
+          "tc_after_anneal": 21.746549,
+          "tc_retained": 21.738694,
+          "surgery_accepted": false
         },
         {
           "round": 4,
-          "score": 3968726.0
+          "tc_before": 21.738694,
+          "tc_after_surgery": 21.738694,
+          "tc_after_anneal": 21.897114,
+          "tc_retained": 21.738694,
+          "surgery_accepted": false
         },
         {
           "round": 5,
-          "score": 3767706.0
+          "tc_before": 21.738694,
+          "tc_after_surgery": 21.738694,
+          "tc_after_anneal": 21.945634,
+          "tc_retained": 21.738694,
+          "surgery_accepted": false
         },
         {
           "round": 6,
-          "score": 3545374.0
+          "tc_before": 21.738694,
+          "tc_after_surgery": 21.738694,
+          "tc_after_anneal": 21.813194,
+          "tc_retained": 21.738694,
+          "surgery_accepted": false
         },
         {
           "round": 7,
-          "score": 3807090.0
+          "tc_before": 21.738694,
+          "tc_after_surgery": 21.738694,
+          "tc_after_anneal": 21.741232,
+          "tc_retained": 21.738694,
+          "surgery_accepted": false
         }
       ]
     },
@@ -631,41 +983,73 @@
     {
       "instance": "sycamore_53_20_0",
       "arm": "treesa_rounds",
-      "tc": 61.483166,
-      "sc": 53.0,
-      "rwc": 60.176556,
+      "tc": 59.906865,
+      "sc": 52.0,
+      "rwc": 58.164362,
       "curve": [
         {
           "round": 0,
-          "score": 7.614967754254335e+22
+          "tc_before": 71.000713,
+          "tc_after_surgery": 71.000713,
+          "tc_after_anneal": 59.913559,
+          "tc_retained": 59.913559,
+          "surgery_accepted": false
         },
         {
           "round": 1,
-          "score": 1.5112139175186644e+23
+          "tc_before": 59.913559,
+          "tc_after_surgery": 59.913559,
+          "tc_after_anneal": 60.026459,
+          "tc_retained": 59.906865,
+          "surgery_accepted": false
         },
         {
           "round": 2,
-          "score": 3.807528270720592e+22
+          "tc_before": 59.906865,
+          "tc_after_surgery": 59.906865,
+          "tc_after_anneal": 59.994782,
+          "tc_retained": 59.906865,
+          "surgery_accepted": false
         },
         {
           "round": 3,
-          "score": 1.948172200072805e+22
+          "tc_before": 59.906865,
+          "tc_after_surgery": 59.906865,
+          "tc_after_anneal": 60.087574,
+          "tc_retained": 59.906865,
+          "surgery_accepted": false
         },
         {
           "round": 4,
-          "score": 2.928291780295957e+19
+          "tc_before": 59.906865,
+          "tc_after_surgery": 59.906865,
+          "tc_after_anneal": 60.040422,
+          "tc_retained": 59.906865,
+          "surgery_accepted": false
         },
         {
           "round": 5,
-          "score": 1.8891122301116535e+22
+          "tc_before": 59.906865,
+          "tc_after_surgery": 59.906865,
+          "tc_after_anneal": 60.018208,
+          "tc_retained": 59.906865,
+          "surgery_accepted": false
         },
         {
           "round": 6,
-          "score": 6.006867197555079e+20
+          "tc_before": 59.906865,
+          "tc_after_surgery": 59.906865,
+          "tc_after_anneal": 59.926639,
+          "tc_retained": 59.906865,
+          "surgery_accepted": false
         },
         {
           "round": 7,
-          "score": 2.401525845741655e+21
+          "tc_before": 59.906865,
+          "tc_after_surgery": 59.906865,
+          "tc_after_anneal": 59.945485,
+          "tc_retained": 59.906865,
+          "surgery_accepted": false
         }
       ]
     },
@@ -686,41 +1070,73 @@
     {
       "instance": "sycamore_m20",
       "arm": "treesa_rounds",
-      "tc": 62.124994,
-      "sc": 54.0,
-      "rwc": 60.742296,
+      "tc": 62.058102,
+      "sc": 53.0,
+      "rwc": 60.859515,
       "curve": [
         {
           "round": 0,
-          "score": 1.511908648110875e+23
+          "tc_before": 73.044662,
+          "tc_after_surgery": 62.547344,
+          "tc_after_anneal": 62.170588,
+          "tc_retained": 62.150339,
+          "surgery_accepted": true
         },
         {
           "round": 1,
-          "score": 3.0230670011367106e+23
+          "tc_before": 62.150339,
+          "tc_after_surgery": 62.150339,
+          "tc_after_anneal": 62.14915,
+          "tc_retained": 62.149149,
+          "surgery_accepted": false
         },
         {
           "round": 2,
-          "score": 1.511215924130222e+23
+          "tc_before": 62.149149,
+          "tc_after_surgery": 62.149149,
+          "tc_after_anneal": 62.256833,
+          "tc_retained": 62.149149,
+          "surgery_accepted": false
         },
         {
           "round": 3,
-          "score": 2.1392381974956995e+20
+          "tc_before": 62.149149,
+          "tc_after_surgery": 62.149149,
+          "tc_after_anneal": 62.195667,
+          "tc_retained": 62.149149,
+          "surgery_accepted": false
         },
         {
           "round": 4,
-          "score": 3.023068103094213e+23
+          "tc_before": 62.149149,
+          "tc_after_surgery": 62.149149,
+          "tc_after_anneal": 62.170587,
+          "tc_retained": 62.149149,
+          "surgery_accepted": false
         },
         {
           "round": 5,
-          "score": 3.022423417768877e+23
+          "tc_before": 62.149149,
+          "tc_after_surgery": 62.115813,
+          "tc_after_anneal": 62.086033,
+          "tc_retained": 62.062447,
+          "surgery_accepted": true
         },
         {
           "round": 6,
-          "score": 6.069737769778972e+23
+          "tc_before": 62.062447,
+          "tc_after_surgery": 62.062447,
+          "tc_after_anneal": 62.101522,
+          "tc_retained": 62.062447,
+          "surgery_accepted": false
         },
         {
           "round": 7,
-          "score": 3.02242196753871e+23
+          "tc_before": 62.062447,
+          "tc_after_surgery": 62.062447,
+          "tc_after_anneal": 62.065354,
+          "tc_retained": 62.058102,
+          "surgery_accepted": false
         }
       ]
     }

--- a/benchmarks/paper/manifest.json
+++ b/benchmarks/paper/manifest.json
@@ -14,6 +14,15 @@
         {"name": "reg3_250", "path": "benchmarks/paper/instances/reg3_250.json", "treewidth": false}
       ]
     },
+    "figure2b": {
+      "arms": {
+        "treesa": {},
+        "treesa_rounds": {"rounds": 32}
+      },
+      "instances": [
+        {"name": "surfacecode_d21", "path": "benchmarks/paper/instances/surfacecode_d21.json", "treewidth": false}
+      ]
+    },
     "full": {
       "arms": {
         "greedy": {},

--- a/benchmarks/paper/plot_figure2b.py
+++ b/benchmarks/paper/plot_figure2b.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+"""Render the deterministic current-main Figure 2(b) reproduction as SVG."""
+
+import html
+import json
+import sys
+from pathlib import Path
+
+
+PRE_SURGERY_RECORD = 47.824
+OFFICIAL_MEDIAN = 47.377
+
+
+def fail(message: str) -> None:
+    raise SystemExit(f"plot_figure2b.py: FAIL: {message}")
+
+
+def main() -> None:
+    if len(sys.argv) != 3:
+        fail("usage: plot_figure2b.py ARTIFACT.json OUTPUT.svg")
+    source, destination = map(Path, sys.argv[1:])
+    artifact = json.loads(source.read_text())
+    rows = {row.get("arm"): row for row in artifact.get("results", [])}
+    if artifact.get("format") != 2 or artifact.get("set") != "figure2b":
+        fail("expected format 2, set figure2b")
+    if set(rows) != {"treesa", "treesa_rounds"}:
+        fail("expected treesa and treesa_rounds rows")
+    curve = rows["treesa_rounds"].get("curve", [])
+    if not curve:
+        fail("treesa_rounds row has no curve")
+
+    width, height = 900, 560
+    left, right, top, bottom = 92, 28, 76, 78
+    plot_width = width - left - right
+    plot_height = height - top - bottom
+    y_values = [rows["treesa"]["tc"], PRE_SURGERY_RECORD, OFFICIAL_MEDIAN]
+    for point in curve:
+        y_values.extend(
+            [
+                point["tc_before"],
+                point["tc_after_surgery"],
+                point["tc_after_anneal"],
+                point["tc_retained"],
+            ]
+        )
+    y_min = min(y_values) - 0.25
+    y_max = max(y_values) + 0.35
+    rounds = len(curve)
+
+    def x(round_index: float) -> float:
+        return left + round_index / rounds * plot_width
+
+    def y(tc: float) -> float:
+        return top + (y_max - tc) / (y_max - y_min) * plot_height
+
+    def esc(value: object) -> str:
+        return html.escape(str(value), quote=True)
+
+    svg = [
+        f'<svg xmlns="http://www.w3.org/2000/svg" width="{width}" height="{height}" viewBox="0 0 {width} {height}">',
+        "<title>Figure 2(b) reproduction from current main</title>",
+        "<desc>Surface-code distance 21 contraction cost over 32 deterministic surgery and cold fine-tuning rounds. Raw fine-tuning endpoints are separated from the retained incumbent.</desc>",
+        '<rect width="100%" height="100%" fill="white"/>',
+        '<g font-family="Helvetica,Arial,sans-serif" fill="#111">',
+        '<text x="92" y="29" font-size="20" font-weight="700">Figure 2(b) reproduction — current main</text>',
+        '<text x="92" y="52" font-size="13" fill="#444">surfacecode_d21; deterministic 32-round work budget; TreeSA defaults</text>',
+    ]
+
+    for tick in range(48, 58, 2):
+        yy = y(tick)
+        svg.append(
+            f'<line x1="{left}" y1="{yy:.2f}" x2="{width-right}" y2="{yy:.2f}" stroke="#e4e4e4" stroke-width="1"/>'
+        )
+        svg.append(
+            f'<text x="{left-12}" y="{yy+4:.2f}" text-anchor="end" font-size="12">{tick}</text>'
+        )
+    for tick in range(0, rounds + 1, 4):
+        xx = x(tick)
+        svg.append(
+            f'<line x1="{xx:.2f}" y1="{top}" x2="{xx:.2f}" y2="{height-bottom}" stroke="#f0f0f0" stroke-width="1"/>'
+        )
+        svg.append(
+            f'<text x="{xx:.2f}" y="{height-bottom+23}" text-anchor="middle" font-size="12">{tick}</text>'
+        )
+
+    svg.extend(
+        [
+            f'<line x1="{left}" y1="{top}" x2="{left}" y2="{height-bottom}" stroke="#111" stroke-width="1.4"/>',
+            f'<line x1="{left}" y1="{height-bottom}" x2="{width-right}" y2="{height-bottom}" stroke="#111" stroke-width="1.4"/>',
+            f'<text x="{left + plot_width/2:.2f}" y="{height-24}" text-anchor="middle" font-size="14">completed surgery/fine-tuning rounds</text>',
+            f'<text x="23" y="{top + plot_height/2:.2f}" text-anchor="middle" font-size="14" transform="rotate(-90 23 {top + plot_height/2:.2f})">contraction cost tc  [log₂ flops]</text>',
+        ]
+    )
+
+    for value, color, dash in [
+        (PRE_SURGERY_RECORD, "#222", "3 5"),
+        (OFFICIAL_MEDIAN, "#cc3311", "9 4 2 4"),
+    ]:
+        yy = y(value)
+        svg.append(
+            f'<line x1="{left}" y1="{yy:.2f}" x2="{width-right}" y2="{yy:.2f}" stroke="{color}" stroke-width="1.5" stroke-dasharray="{dash}"/>'
+        )
+
+    retained = [(0.0, rows["treesa"]["tc"])]
+    retained.extend((point["round"] + 1.0, point["tc_retained"]) for point in curve)
+    points = " ".join(f"{x(xx):.2f},{y(yy):.2f}" for xx, yy in retained)
+    svg.append(
+        f'<polyline points="{points}" fill="none" stroke="#0072b2" stroke-width="2.8" stroke-linejoin="round" stroke-linecap="round"/>'
+    )
+
+    for point in curve:
+        xx = x(point["round"] + 1.0)
+        endpoint_y = y(point["tc_after_anneal"])
+        svg.append(
+            f'<circle cx="{xx:.2f}" cy="{endpoint_y:.2f}" r="3.1" fill="white" stroke="#777" stroke-width="1.3"/>'
+        )
+        if point["surgery_accepted"]:
+            surgery_y = y(point["tc_after_surgery"])
+            svg.extend(
+                [
+                    f'<line x1="{xx-5:.2f}" y1="{surgery_y-5:.2f}" x2="{xx+5:.2f}" y2="{surgery_y+5:.2f}" stroke="#cc3311" stroke-width="2.2"/>',
+                    f'<line x1="{xx-5:.2f}" y1="{surgery_y+5:.2f}" x2="{xx+5:.2f}" y2="{surgery_y-5:.2f}" stroke="#cc3311" stroke-width="2.2"/>',
+                ]
+            )
+
+    legend_x, legend_y = 520, 91
+    svg.extend(
+        [
+            f'<rect x="{legend_x-12}" y="{legend_y-18}" width="360" height="105" fill="white" fill-opacity="0.92" stroke="#bbb"/>',
+            f'<line x1="{legend_x}" y1="{legend_y}" x2="{legend_x+28}" y2="{legend_y}" stroke="#0072b2" stroke-width="2.8"/><text x="{legend_x+38}" y="{legend_y+4}" font-size="12">retained incumbent</text>',
+            f'<circle cx="{legend_x+14}" cy="{legend_y+22}" r="3.1" fill="white" stroke="#777" stroke-width="1.3"/><text x="{legend_x+38}" y="{legend_y+26}" font-size="12">raw fine-tuning endpoint</text>',
+            f'<path d="M {legend_x+9} {legend_y+39} l 10 10 m -10 0 l 10 -10" stroke="#cc3311" stroke-width="2.2"/><text x="{legend_x+38}" y="{legend_y+48}" font-size="12">accepted waist rebuild</text>',
+            f'<line x1="{legend_x}" y1="{legend_y+66}" x2="{legend_x+28}" y2="{legend_y+66}" stroke="#222" stroke-width="1.5" stroke-dasharray="3 5"/><text x="{legend_x+38}" y="{legend_y+70}" font-size="12">pre-surgery record 47.824</text>',
+            f'<line x1="{legend_x+190}" y1="{legend_y+66}" x2="{legend_x+218}" y2="{legend_y+66}" stroke="#cc3311" stroke-width="1.5" stroke-dasharray="9 4 2 4"/><text x="{legend_x+228}" y="{legend_y+70}" font-size="12">official median 47.377</text>',
+            f'<text x="{left}" y="{height-5}" font-size="10" fill="#555">Source: {esc(source.name)}; final retained tc = {rows["treesa_rounds"]["tc"]:.6f}</text>',
+            "</g></svg>",
+        ]
+    )
+    destination.write_text("\n".join(svg) + "\n")
+    print(f"wrote {destination}")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/paper/verify_figure2b.py
+++ b/benchmarks/paper/verify_figure2b.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""Verify the semantic contract behind the Figure 2(b) reproduction set."""
+
+import json
+import sys
+from pathlib import Path
+
+
+PRE_SURGERY_RECORD = 47.824
+
+
+def fail(message: str) -> None:
+    raise SystemExit(f"verify_figure2b.py: FAIL: {message}")
+
+
+def main() -> None:
+    if len(sys.argv) != 2:
+        fail("usage: verify_figure2b.py ARTIFACT.json")
+    artifact = json.loads(Path(sys.argv[1]).read_text())
+    if artifact.get("format") != 2 or artifact.get("set") != "figure2b":
+        fail("expected format 2, set figure2b")
+
+    rows = {row.get("arm"): row for row in artifact.get("results", [])}
+    if set(rows) != {"treesa", "treesa_rounds"}:
+        fail(f"expected treesa and treesa_rounds rows, got {sorted(rows)}")
+    baseline = rows["treesa"]
+    surgery = rows["treesa_rounds"]
+    if surgery["tc"] >= PRE_SURGERY_RECORD:
+        fail(
+            f"surgery tc={surgery['tc']} does not cross the Figure 2(b) "
+            f"record {PRE_SURGERY_RECORD}"
+        )
+    if surgery["tc"] >= baseline["tc"]:
+        fail("surgery does not improve the plain TreeSA baseline")
+
+    curve = surgery.get("curve", [])
+    if len(curve) != 32:
+        fail(f"expected 32 fixed-work rounds, got {len(curve)}")
+    accepted_drops = 0
+    worse_endpoints = 0
+    previous = None
+    for point in curve:
+        if point["tc_retained"] > point["tc_before"]:
+            fail(f"retained incumbent rises in round {point['round']}")
+        if previous is not None and point["tc_before"] != previous:
+            fail(f"round {point['round']} does not continue from the retained incumbent")
+        if point["surgery_accepted"] and point["tc_after_surgery"] < point["tc_before"]:
+            accepted_drops += 1
+        if point["tc_after_anneal"] > point["tc_before"]:
+            worse_endpoints += 1
+        previous = point["tc_retained"]
+    if accepted_drops == 0:
+        fail("no accepted waist rebuild initiates a tc drop")
+    if worse_endpoints == 0:
+        fail("fine-tuning endpoint never exposes an uphill excursion")
+    if previous != surgery["tc"]:
+        fail(f"final retained tc={previous} differs from row tc={surgery['tc']}")
+
+    print(
+        f"OK: tc={surgery['tc']} < {PRE_SURGERY_RECORD}; "
+        f"accepted rebuild drops={accepted_drops}; uphill endpoints={worse_endpoints}; "
+        f"rounds={len(curve)}"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/src/algorithms/default-pipeline.md
+++ b/docs/src/algorithms/default-pipeline.md
@@ -8,7 +8,8 @@ pass. This page documents what runs, what it guarantees, and how to opt out.
 ## What `TreeSA::default()` runs
 
 ```
-simplify  ->  anneal trials (on the reduced network)  ->  splice  ->  [k x (surgery -> anneal), if k > 0]
+simplify  ->  anneal trials  ->  [k x (surgery -> cold fine tune)]  ->  splice
+                           (all search runs on the reduced network)
 ```
 
 1. **Simplify** ([`crate::preprocess::simplify`]) deterministically fuses
@@ -17,26 +18,39 @@ simplify  ->  anneal trials (on the reduced network)  ->  splice  ->  [k x (surg
    network.
 2. **Anneal trials** run the normal TreeSA search loop on that reduced
    network instead of the raw one, so the search budget is spent where it
-   matters.
-3. **Splice** ([`crate::preprocess::splice`]) expands each reduced-network
-   leaf back into the binary subtree `simplify` merged it from, so the
-   returned tree's leaves are exactly the original tensors again.
-4. **Interleaved anneal–surgery rounds** (the companion paper's Algorithm 1)
+   matters. With `surgery_probability > 0`, each scheduled sweep independently
+   selects one global waist update with that probability; otherwise it runs the
+   ordinary local sweep. The global proposal moves one boundary tensor across
+   the current waist with a leaf prune-and-regraft edit, preserving every
+   unaffected subtree, and uses the ordinary Metropolis test at the current
+   inverse temperature.
+   It does not change the temperature, consult a clock, or launch another
+   annealing loop. The default probability is `0.0`, so existing runs are
+   byte-identical.
+3. **Interleaved anneal–surgery rounds** (the companion paper's Algorithm 1)
    only run if [`TreeSA::surgery_iters`] is greater than `0` (the default is
    `0`, off). `surgery_iters` counts *rounds*, and each round is one
    waist-surgery iteration ([`crate::waist_surgery::refine_capped`]) on the
-   current tree — improving its most expensive contraction, its *waist* —
-   followed by a full warm-started annealing pass over the surgical result.
-   The loop returns the best tree it saw anywhere, so it can only help.
+   current reduced-network tree — improving its most expensive contraction,
+   its *waist* —
+   followed by a cold specified-tree fine-tuning pass over the surgical result:
+   at most 15 configured levels with `β >= 1`, 30 span-gated sweeps per
+   coarse-to-fine span, and three deterministic serial trials. The loop returns
+   the best tree it saw anywhere, so it can only help.
 
-   Rounds are *chained*: round `r + 1` continues from round `r`'s annealed
-   tree even when that tree was worse than the incumbent best. Letting the
-   trajectory go uphill is the point — it is what lets surgery carry the
-   search out of a basin that local annealing moves cannot leave.
+   Rounds use an *incumbent ratchet*: a worse fine-tuning endpoint is reported
+   but rejected, and round `r + 1` starts from the best tree retained in round
+   `r`. Surgery supplies the nonlocal basin jump; fine tuning need not destroy
+   the incumbent to provide one.
 
-   **Cost: one round ≈ one more full anneal of the network**, so runtime grows
-   roughly linearly in `surgery_iters`. Budget it like extra trials, not like
-   a cheap post-pass.
+   **Cost:** on the 761-tensor simplified surface-code network, fine tuning is
+   450 sweeps per round, versus 15,000 sweeps for a default cold-start trial.
+   Runtime still grows roughly linearly in `surgery_iters`.
+4. **Splice** ([`crate::preprocess::splice`]) expands each reduced-network
+   leaf back into the binary subtree `simplify` merged it from, so the
+   returned tree's leaves are exactly the original tensors again. Splicing
+   happens after the optional rounds: the paper's waist and FM cut are defined
+   on the simplified hypergraph.
 
 This whole pipeline is what `optimize_code(ixs, out, sizes, TreeSA())` /
 `optimize_code(&code, &sizes, &TreeSA::default())` runs by default — no flags
@@ -64,8 +78,10 @@ rather than seconds — the anneal–surgery loop too are all pure functions of
 the input network and config (internal RNG seeds are fixed, and no wall-clock
 deadline binds `optimize_treesa`). Re-running the same configuration
 reproduces the same tree on any machine, with `surgery_iters` at any value:
-`0` (off), or any positive round count. More rounds can only be equal or
-better, never worse.
+`0` (off), or any positive round count. Every positive-round result is guarded
+against the rounds-off baseline after splice-back. The standalone
+`anneal_surgery_rounds` loop is monotone in its round count on the network it
+is given.
 
 Wall-clock budgets still exist, but only on the low-level
 [`crate::waist_surgery::refine`] / [`refine_capped`] APIs (and the Python
@@ -107,7 +123,7 @@ tensor hypergraph with balance-constrained Fiduccia–Mattheyses passes, and
 only keeps the result if it strictly lowers `tc`.
 
 Interleaving matters as much as the surgery itself: a surgical cut is a jump
-to a different basin, and the annealing pass that follows it in the same
+to a different basin, and the cold fine-tuning pass that follows it in the same
 round is what settles the rest of the tree around the new cut. That is why
 `surgery_iters` runs rounds rather than back-to-back surgery iterations.
 
@@ -118,14 +134,14 @@ round is what settles the rest of the tree around the new cut. That is why
   a strictly cheaper comparable-balance cut.
 - **Near-no-op elsewhere.** On instances without a frozen waist, surgery's
   bounded search typically returns early after confirming the incumbent cut
-  is locally minimal — the round then degenerates to an extra warm-started
-  anneal, which costs time but never regresses the returned tree.
+  is locally minimal — the round then degenerates to a cold fine-tuning pass,
+  which costs time but never regresses the returned tree.
 
 If you don't know in advance whether your network has this structure, a small
 positive `surgery_iters` is a safe thing to try: worst case you spend a few
-extra anneals for no improvement, best case you recover a meaningfully
-cheaper tree. Since each round costs about one anneal, start at 2–5 rounds
-and scale up only if the trajectory is still improving.
+extra fine-tuning passes for no improvement, best case you recover a
+meaningfully cheaper tree. Start at 2–5 rounds and scale up only if the
+retained trajectory is still improving.
 
 ## Escape hatches
 
@@ -142,10 +158,11 @@ spliced tree a node with two non-leaf children and break that preset's
 documented linear-contraction-order guarantee, so it opts out unconditionally
 rather than risk it.
 
-For the same reason, a `Path` decomposition also skips the anneal–surgery
-rounds: neither the surgical rebuild nor the warm-started anneal is
-path-preserving. Setting `surgery_iters` on a path config is silently ignored
-rather than allowed to return a non-path tree.
+For the same reason, a `Path` decomposition also skips both forms of surgery:
+the anneal–surgery rounds and the probabilistic surgery update rule. Neither
+the surgical rebuild nor the specified-tree fine tuning is path-preserving.
+Setting `surgery_iters` or `surgery_probability` on a path config is silently
+ignored rather than allowed to return a non-path tree.
 
 ## See also
 

--- a/omeco-python/python/omeco/__init__.py
+++ b/omeco-python/python/omeco/__init__.py
@@ -15,7 +15,8 @@ Classes:
         ExhaustiveSearch(verbose=False)
 
     TreeSA: Simulated annealing optimizer.
-        TreeSA(ntrials=10, niters=50, betas=None, score=None, preprocess=True, surgery_iters=0)
+        TreeSA(ntrials=10, niters=50, betas=None, score=None,
+               preprocess=True, surgery_iters=0, surgery_probability=0.0)
         TreeSA.fast(score=None)
 
     Treewidth: Scalable treewidth-heuristic elimination-order optimizer.

--- a/omeco-python/src/lib.rs
+++ b/omeco-python/src/lib.rs
@@ -545,15 +545,18 @@ impl PyTreeSA {
     ///     score: Score function for evaluating solutions. If None, uses default.
     ///     preprocess: Simplify the network (splice degree-2/parallel tensors) before
     ///                 annealing, then splice the reduced tree back (default: True).
-    ///     surgery_iters: Number of interleaved anneal-surgery rounds run after
-    ///                    the pipeline (each round is one waist-surgery
-    ///                    iteration plus a warm-started anneal, so it costs
-    ///                    about one full anneal); 0 disables the loop
-    ///                    (default: 0). The best tree seen is returned, so more
-    ///                    rounds are never worse, and the loop is deterministic
-    ///                    and reproducible across machines for any fixed config.
+    ///     surgery_iters: Number of interleaved anneal-surgery rounds run on
+    ///                    the reduced network before splice-back (each round is
+    ///                    one waist-surgery iteration plus cold span-gated fine
+    ///                    tuning); 0 disables the loop (default: 0). After
+    ///                    splice-back, the result is guarded against the
+    ///                    rounds-off baseline and is reproducible for any fixed
+    ///                    config.
+    ///     surgery_probability: Probability that a local TreeSA sweep is
+    ///                          replaced by one waist-surgery update at the
+    ///                          current temperature (default: 0.0).
     #[new]
-    #[pyo3(signature = (ntrials=10, niters=50, betas=None, score=None, preprocess=true, surgery_iters=0))]
+    #[pyo3(signature = (ntrials=10, niters=50, betas=None, score=None, preprocess=true, surgery_iters=0, surgery_probability=0.0))]
     fn new(
         ntrials: usize,
         niters: usize,
@@ -561,22 +564,29 @@ impl PyTreeSA {
         score: Option<PyScoreFunction>,
         preprocess: bool,
         surgery_iters: u64,
-    ) -> Self {
-        let default_betas: Vec<f64> = (1..=300).map(|i| 0.01 + 0.05 * i as f64).collect();
-        let betas = betas.unwrap_or(default_betas);
-        let score = score.map(|s| s.inner).unwrap_or_default();
-
-        Self {
-            inner: TreeSA {
-                betas,
-                ntrials,
-                niters,
-                score,
-                preprocess,
-                surgery_iters,
-                ..Default::default()
-            },
+        surgery_probability: f64,
+    ) -> PyResult<Self> {
+        if !surgery_probability.is_finite() || !(0.0..=1.0).contains(&surgery_probability) {
+            return Err(PyValueError::new_err(
+                "surgery_probability must be finite and in [0, 1]",
+            ));
         }
+        let defaults = TreeSA::default();
+        let betas = betas.unwrap_or_else(|| defaults.betas.clone());
+        let score = score
+            .map(|score| score.inner)
+            .unwrap_or_else(|| defaults.score.clone());
+        let inner = TreeSA {
+            betas,
+            ntrials,
+            niters,
+            score,
+            preprocess,
+            surgery_iters,
+            surgery_probability,
+            ..defaults
+        };
+        Ok(Self { inner })
     }
 
     /// Create a fast TreeSA configuration (fewer iterations).
@@ -625,17 +635,23 @@ impl PyTreeSA {
         self.inner.preprocess
     }
 
-    /// Number of interleaved anneal-surgery rounds run after the pipeline;
-    /// each round is one waist-surgery iteration plus a warm-started anneal,
-    /// so it costs about one full anneal. 0 disables the loop.
+    /// Number of interleaved anneal-surgery rounds run on the reduced network
+    /// before splice-back; each round is one waist-surgery iteration plus cold
+    /// span-gated fine tuning. 0 disables the loop.
     #[getter]
     fn surgery_iters(&self) -> u64 {
         self.inner.surgery_iters
     }
 
+    /// Probability that a local sweep is replaced by a surgery update.
+    #[getter]
+    fn surgery_probability(&self) -> f64 {
+        self.inner.surgery_probability
+    }
+
     fn __repr__(&self) -> String {
         format!(
-            "TreeSA(ntrials={}, niters={}, score={}, preprocess={}, surgery_iters={})",
+            "TreeSA(ntrials={}, niters={}, score={}, preprocess={}, surgery_iters={}, surgery_probability={})",
             self.inner.ntrials,
             self.inner.niters,
             PyScoreFunction {
@@ -648,6 +664,7 @@ impl PyTreeSA {
                 "False"
             },
             self.inner.surgery_iters,
+            self.inner.surgery_probability,
         )
     }
 }
@@ -924,7 +941,10 @@ fn optimize_treesa(
     optimizer: Option<PyTreeSA>,
 ) -> PyResult<PyNestedEinsum> {
     let code = EinCode::new(ixs, out);
-    let opt = optimizer.unwrap_or_else(|| PyTreeSA::new(10, 50, None, None, true, 0));
+    let opt = match optimizer {
+        Some(opt) => opt,
+        None => PyTreeSA::new(10, 50, None, None, true, 0, 0.0)?,
+    };
 
     opt.inner
         .optimize(&code, &sizes)

--- a/omeco-python/tests/test_omeco.py
+++ b/omeco-python/tests/test_omeco.py
@@ -471,21 +471,44 @@ def test_treesa_getters():
     assert len(opt.betas) > 0
 
 
+def test_treesa_default_beta_schedule_matches_rust():
+    opt = TreeSA()
+    assert len(opt.betas) == 300
+    assert opt.betas[0] == 0.01
+    assert opt.betas[-1] == 14.96
+
+
 def test_treesa_repr():
-    """__repr__ must surface preprocess and surgery_iters, not just ntrials/niters/score."""
-    opt = TreeSA(ntrials=3, niters=15, preprocess=False, surgery_iters=7)
+    """__repr__ must surface every pipeline/update-rule knob."""
+    opt = TreeSA(
+        ntrials=3,
+        niters=15,
+        preprocess=False,
+        surgery_iters=7,
+        surgery_probability=0.001,
+    )
     repr_str = repr(opt)
     assert "TreeSA" in repr_str
     assert "ntrials=3" in repr_str
     assert "niters=15" in repr_str
     assert "preprocess=False" in repr_str
     assert "surgery_iters=7" in repr_str
+    assert "surgery_probability=0.001" in repr_str
 
 
 def test_treesa_surgery_iters_getter_and_default():
     """surgery_iters defaults to 0 and round-trips through the constructor."""
     assert TreeSA().surgery_iters == 0
     assert TreeSA(surgery_iters=7).surgery_iters == 7
+
+
+def test_treesa_surgery_probability_getter_and_validation():
+    """The update-rule probability defaults off and rejects invalid values."""
+    assert TreeSA().surgery_probability == 0.0
+    assert TreeSA(surgery_probability=0.001).surgery_probability == 0.001
+    for probability in (-0.01, 1.01, float("nan"), float("inf")):
+        with pytest.raises(ValueError, match="finite and in \\[0, 1\\]"):
+            TreeSA(surgery_probability=probability)
 
 
 # ============== New tests for TreeSASlicer constructor ==============

--- a/omeco/examples/paper_bench.rs
+++ b/omeco/examples/paper_bench.rs
@@ -31,7 +31,8 @@ use std::time::Instant;
 
 use omeco::treesa::anneal_surgery_rounds;
 use omeco::{
-    contraction_complexity, optimize_code, EinCode, GreedyMethod, NestedEinsum, TreeSA, Treewidth,
+    contraction_complexity, optimize_code, simplify, splice, EinCode, GreedyMethod, NestedEinsum,
+    TreeSA, Treewidth,
 };
 use serde::{Deserialize, Serialize};
 
@@ -68,6 +69,7 @@ struct ArmsSpec {
     greedy: Option<GreedyArm>,
     treesa: Option<TreeSAArm>,
     treesa_rounds: Option<RoundsArm>,
+    treesa_surgery_rule: Option<SurgeryRuleArm>,
 }
 
 /// The greedy arm takes no configuration; `{}` is the only legal value.
@@ -90,6 +92,14 @@ struct RoundsArm {
     /// Required: a rounds arm without a round count is a manifest bug, not a
     /// request for zero rounds.
     rounds: u64,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct SurgeryRuleArm {
+    ntrials: Option<usize>,
+    niters: Option<usize>,
+    probability: f64,
 }
 
 #[derive(Debug, Deserialize)]
@@ -136,16 +146,19 @@ struct ResultRow {
     tc: f64,
     sc: f64,
     rwc: f64,
-    /// Per-round trajectory score, emitted by the `treesa_rounds` arm only.
+    /// Per-round retained-incumbent trace, emitted by `treesa_rounds` only.
     #[serde(skip_serializing_if = "Option::is_none")]
     curve: Option<Vec<CurvePoint>>,
 }
 
 #[derive(Debug, Serialize)]
 struct CurvePoint {
-    /// Zero-based round index, matching `RoundsReport::best_round`.
     round: u64,
-    score: f64,
+    tc_before: f64,
+    tc_after_surgery: f64,
+    tc_after_anneal: f64,
+    tc_retained: f64,
+    surgery_accepted: bool,
 }
 
 // ---------------------------------------------------------------------------
@@ -320,20 +333,29 @@ fn run_instance(
 
     if let Some(arm) = &arms.treesa_rounds {
         let started = Instant::now();
-        // The seed is the plain `treesa` result under this arm's own
-        // overrides; driving `anneal_surgery_rounds` directly (rather than
-        // setting `surgery_iters`) is bit-identical and additionally exposes
-        // the per-round trajectory.
-        let config = treesa_config(arm.ntrials, arm.niters);
-        let seed = optimized(optimize_code(code, sizes, &config), "treesa_rounds");
-        let (tree, report) = anneal_surgery_rounds(&seed, code, sizes, &config, arm.rounds);
+        // Match `optimize_treesa`: simplify, anneal and run the rounds on the
+        // reduced hypergraph, then restore the retained contractions. Driving
+        // the public stages explicitly exposes the per-round trajectory.
+        let simplified = simplify(code, sizes);
+        let mut config = treesa_config(arm.ntrials, arm.niters);
+        config.preprocess = false;
+        let seed = optimized(
+            optimize_code(&simplified.code, sizes, &config),
+            "treesa_rounds",
+        );
+        let (reduced, report) =
+            anneal_surgery_rounds(&seed, &simplified.code, sizes, &config, arm.rounds);
+        let tree = splice(&reduced, &simplified.subtrees);
         let curve = report
-            .round_scores
+            .round_trace
             .iter()
-            .enumerate()
-            .map(|(i, s)| CurvePoint {
-                round: i as u64,
-                score: round6(*s),
+            .map(|trace| CurvePoint {
+                round: trace.round,
+                tc_before: round6(trace.tc_before),
+                tc_after_surgery: round6(trace.tc_after_surgery),
+                tc_after_anneal: round6(trace.tc_after_anneal),
+                tc_retained: round6(trace.tc_retained),
+                surgery_accepted: trace.surgery_accepted,
             })
             .collect();
         rows.push(row(
@@ -345,6 +367,28 @@ fn run_instance(
             Some(curve),
         ));
         report_progress(&spec.name, "treesa_rounds", started);
+    }
+
+    if let Some(arm) = &arms.treesa_surgery_rule {
+        let started = Instant::now();
+        if !arm.probability.is_finite() || !(0.0..=1.0).contains(&arm.probability) {
+            fail(&format!(
+                "instance `{}`: arm `treesa_surgery_rule` probability must be finite and in [0, 1], got {}",
+                spec.name, arm.probability
+            ));
+        }
+        let config =
+            treesa_config(arm.ntrials, arm.niters).with_surgery_probability(arm.probability);
+        let tree = optimized(optimize_code(code, sizes, &config), "treesa_surgery_rule");
+        rows.push(row(
+            &spec.name,
+            "treesa_surgery_rule",
+            &tree,
+            code,
+            sizes,
+            None,
+        ));
+        report_progress(&spec.name, "treesa_surgery_rule", started);
     }
 
     if spec.treewidth {
@@ -397,7 +441,7 @@ fn main() {
     results.sort_by(|a, b| (&a.instance, &a.arm).cmp(&(&b.instance, &b.arm)));
 
     let output = Output {
-        format: 1,
+        format: 2,
         set: args.set,
         results,
     };

--- a/omeco/src/eincode.rs
+++ b/omeco/src/eincode.rs
@@ -920,6 +920,7 @@ mod tests {
             score: Default::default(),
             preprocess: false,
             surgery_iters: 0,
+            surgery_probability: 0.0,
         };
         let treesa_result = optimize_treesa(&code, &sizes, &treesa_config).unwrap();
 

--- a/omeco/src/treesa.rs
+++ b/omeco/src/treesa.rs
@@ -5,12 +5,16 @@
 //! the Metropolis criterion.
 
 use crate::eincode::{EinCode, NestedEinsum};
-use crate::expr_tree::{apply_rule_mut, DecompositionType, ExprTree, Rule, ScratchSpace};
+use crate::expr_tree::{
+    apply_rule_mut, tree_complexity, DecompositionType, ExprTree, Rule, ScratchSpace,
+};
 use crate::greedy::{optimize_greedy, GreedyMethod};
 use crate::preprocess::{simplify, splice};
 use crate::score::ScoreFunction;
 use crate::utils::fast_log2sumexp2;
+#[cfg(test)]
 use crate::waist_surgery::refine_capped;
+use crate::waist_surgery::{gated_sweep, refine_capped_seeded, WaistUpdate};
 use crate::Label;
 use rand::prelude::*;
 use rayon::prelude::*;
@@ -43,20 +47,26 @@ pub struct TreeSA {
     /// Number of interleaved anneal–surgery rounds ([`anneal_surgery_rounds`],
     /// the paper's Algorithm 1) run on the tree the pipeline selected; `0`
     /// disables the loop entirely (the default). Each round applies one
-    /// waist-surgery iteration and then a full warm-started annealing pass, so
-    /// **one round costs roughly one more anneal of the network** — this knob
-    /// buys quality with time, roughly linearly.
+    /// waist-surgery iteration and then a cold fine-tuning pass: at most 15
+    /// stratified configured levels with `β >= 1`, at most 30 span-gated sweeps
+    /// per coarse-to-fine span, and at most three deterministic serial trials.
+    /// This follows TensorBranching's specified-tree `TreeSARefiner` policy and
+    /// avoids restarting an already optimized tree at the default schedule's
+    /// hot end.
     ///
-    /// The best tree seen anywhere in the loop is returned, so the result is
-    /// never worse than with the loop off, and `k + 1` rounds are always equal
-    /// or better than `k`. See [`crate::waist_surgery`] for the surgery step
-    /// itself.
+    /// The best reduced-network tree seen in the loop is returned. After
+    /// splice-back, [`optimize_treesa`] compares it with the rounds-off result
+    /// on the original network, so enabling any positive round count is never
+    /// worse than leaving the loop off. The standalone
+    /// [`anneal_surgery_rounds`] loop is additionally monotone in its round
+    /// count on the network it is given. See [`crate::waist_surgery`] for the
+    /// surgery step itself.
     ///
     /// # Path decomposition
     ///
     /// [`optimize_treesa`] auto-skips the rounds loop (treating this field as
     /// `0`) whenever `decomposition_type` is [`DecompositionType::Path`]:
-    /// neither surgery nor the warm-started anneal preserves the
+    /// neither surgery nor the specified-tree fine tuning preserves the
     /// path-decomposition guarantee. See [`TreeSA::path`].
     ///
     /// # Determinism
@@ -69,6 +79,14 @@ pub struct TreeSA {
     ///
     /// [`refine_capped`]: crate::waist_surgery::refine_capped
     pub surgery_iters: u64,
+    /// Probability that a TreeSA sweep is replaced by one global waist-surgery
+    /// proposal. The proposal is accepted by the Metropolis rule at the current
+    /// inverse temperature; cooling then continues without a restart or a
+    /// post-surgery anneal. `0.0` disables the rule (the default).
+    ///
+    /// The rule is skipped for [`DecompositionType::Path`] because the global
+    /// repartition is not path-preserving.
+    pub surgery_probability: f64,
 }
 
 /// Method for initializing the contraction tree.
@@ -94,6 +112,7 @@ impl Default for TreeSA {
             decomposition_type: DecompositionType::Tree,
             preprocess: true,
             surgery_iters: 0,
+            surgery_probability: 0.0,
         }
     }
 }
@@ -116,6 +135,7 @@ impl TreeSA {
             decomposition_type: DecompositionType::Tree,
             preprocess: true,
             surgery_iters: 0,
+            surgery_probability: 0.0,
         }
     }
 
@@ -141,9 +161,11 @@ impl TreeSA {
     /// (see [`NestedEinsum::is_path_decomposition`]).
     ///
     /// For the same reason, [`optimize_treesa`] also skips the
-    /// [`TreeSA::surgery_iters`] rounds loop for path configs: waist surgery
-    /// rebuilds subtrees around a re-optimized cut and the warm-started anneal
-    /// applies general binary-tree moves, neither of which is path-preserving.
+    /// [`TreeSA::surgery_iters`] rounds loop and the
+    /// [`TreeSA::surgery_probability`] update rule for path configs: waist
+    /// surgery rebuilds subtrees around a re-optimized cut and the
+    /// specified-tree fine tuner applies general binary-tree moves, neither of which
+    /// is path-preserving.
     pub fn path() -> Self {
         Self {
             initializer: Initializer::Random,
@@ -201,10 +223,10 @@ impl TreeSA {
 
     /// Set the number of interleaved anneal–surgery rounds (0 disables).
     ///
-    /// Each round costs roughly one extra full anneal of the network; the
-    /// returned tree is the best seen, so more rounds are never worse. The
-    /// loop is skipped for [`DecompositionType::Path`] configs (it is not
-    /// path-preserving). See [`TreeSA::surgery_iters`].
+    /// Each round uses the cold specified-tree fine-tuning policy documented on
+    /// [`TreeSA::surgery_iters`]; the end-to-end result is guarded against the
+    /// rounds-off baseline. The loop is skipped for
+    /// [`DecompositionType::Path`] configs (it is not path-preserving).
     ///
     /// # Example
     ///
@@ -223,6 +245,21 @@ impl TreeSA {
     /// ```
     pub fn with_surgery_iters(mut self, rounds: u64) -> Self {
         self.surgery_iters = rounds;
+        self
+    }
+
+    /// Set the probability that one local sweep is replaced by a global
+    /// surgery proposal at the same inverse temperature.
+    ///
+    /// # Panics
+    ///
+    /// Panics unless `probability` is finite and in `[0, 1]`.
+    pub fn with_surgery_probability(mut self, probability: f64) -> Self {
+        assert!(
+            probability.is_finite() && (0.0..=1.0).contains(&probability),
+            "surgery probability must be finite and in [0, 1]"
+        );
+        self.surgery_probability = probability;
         self
     }
 }
@@ -512,6 +549,171 @@ fn optimize_tree_sa<R: Rng>(
     tree
 }
 
+/// Cold, sparse schedule for refining an already-optimized tree.
+///
+/// TensorBranching's `TreeSARefiner` uses `β = 1:1:15`: a specified-tree
+/// refinement does not need the initializer-forgetting, high-temperature end
+/// of the default TreeSA schedule. Preserve custom schedules that contain no
+/// `β >= 1`, and otherwise retain at most 15 stratified cold levels.
+fn fine_tune_beta_schedule(betas: &[f64]) -> Vec<f64> {
+    const MAX_LEVELS: usize = 15;
+    let cold: Vec<f64> = betas.iter().copied().filter(|beta| *beta >= 1.0).collect();
+    let source = if cold.is_empty() { betas } else { &cold };
+    if source.len() <= MAX_LEVELS {
+        return source.to_vec();
+    }
+    let last = source.len() - 1;
+    (0..MAX_LEVELS)
+        .map(|i| source[i * last / (MAX_LEVELS - 1)])
+        .collect()
+}
+
+/// Fine-tune a specified tree and return `(best_seen, final_endpoint)`.
+///
+/// The endpoint remains useful diagnostics for fine-tuning damage, but the
+/// paper's `Anneal` operator returns its best tree. The relaxation uses the
+/// span-gated kernel from attempt-054: each level of the coarse-to-fine span
+/// ladder receives `sweeps_per_span` sweeps across the cold beta schedule. The
+/// tree is rescored after every sweep with the caller's emitted-tree scorer, so
+/// a later uphill sweep cannot erase an earlier, better checkpoint.
+fn fine_tune_tree_sa<F>(
+    mut tree: ExprTree,
+    log2_sizes: &[f64],
+    betas: &[f64],
+    sweeps_per_span: usize,
+    score_tree: &F,
+    rng: &mut rand::rngs::SmallRng,
+    nedge: usize,
+) -> (ExprTree, ExprTree)
+where
+    F: Fn(&ExprTree) -> f64,
+{
+    let mut best = tree.clone();
+    let mut best_score = score_tree(&best);
+    let mut scratch = ScratchSpace::new(nedge);
+    let mut s_lin = f64::exp2(tree_complexity(&tree, log2_sizes).0);
+
+    let n = tree.leaf_count();
+    let mut span = ((n + 29) / 30).max(2);
+    let mut spans = Vec::new();
+    while span > 2 {
+        spans.push(span);
+        span /= 2;
+    }
+    spans.push(2);
+
+    if !betas.is_empty() {
+        let denom = sweeps_per_span.saturating_sub(1).max(1);
+        for span in spans {
+            for sweep in 0..sweeps_per_span {
+                let beta_index = sweep * (betas.len() - 1) / denom;
+                gated_sweep(
+                    &mut tree,
+                    betas[beta_index],
+                    span,
+                    log2_sizes,
+                    rng,
+                    &mut scratch,
+                    &mut s_lin,
+                );
+                let candidate_score = score_tree(&tree);
+                if candidate_score < best_score {
+                    best_score = candidate_score;
+                    best = tree.clone();
+                }
+            }
+            s_lin = f64::exp2(tree_complexity(&tree, log2_sizes).0);
+        }
+    }
+    (best, tree)
+}
+
+/// Run TreeSA with a root-level mixture of local sweeps and global surgery
+/// proposals. Surgery replaces a sweep, uses the current beta, and never
+/// changes or restarts the cooling schedule.
+#[allow(clippy::too_many_arguments)]
+fn optimize_tree_sa_mixed<R: Rng>(
+    mut tree: ExprTree,
+    log2_sizes: &[f64],
+    betas: &[f64],
+    niters: usize,
+    score: &ScoreFunction,
+    decomp: DecompositionType,
+    rng: &mut R,
+    nedge: usize,
+    surgery: &WaistUpdate,
+    surgery_probability: f64,
+) -> ExprTree {
+    let log2_rw_weight = if score.rw_weight > 0.0 {
+        score.rw_weight.log2()
+    } else {
+        f64::NEG_INFINITY
+    };
+    let mut scratch = ScratchSpace::new(nedge);
+
+    for &beta in betas {
+        for _ in 0..niters {
+            if rng.random::<f64>() < surgery_probability {
+                if let Some(candidate) = surgery.propose(&tree, rng) {
+                    let before = tree_complexity(&tree, log2_sizes);
+                    let after = tree_complexity(&candidate, log2_sizes);
+                    let d_energy = surgery_energy_difference(
+                        before,
+                        after,
+                        score.sc_target,
+                        score.sc_weight,
+                        log2_rw_weight,
+                    );
+                    if rng.random::<f64>() < (-beta * d_energy).exp() {
+                        tree = candidate;
+                        scratch = ScratchSpace::new(nedge);
+                    }
+                }
+            } else {
+                optimize_subtree_mut(
+                    &mut tree,
+                    beta,
+                    log2_sizes,
+                    score.sc_target,
+                    score.sc_weight,
+                    log2_rw_weight,
+                    decomp,
+                    rng,
+                    &mut scratch,
+                );
+            }
+        }
+    }
+    tree
+}
+
+/// Whole-tree analogue of TreeSA's local rewrite energy difference.
+///
+/// Complexity values stay in log2 units. In particular, this must not call
+/// `ScoreFunction::evaluate`, whose linear `2^tc` scale is not the scale to
+/// which TreeSA's beta schedule is calibrated.
+#[inline]
+fn surgery_energy_difference(
+    before: (f64, f64, f64),
+    after: (f64, f64, f64),
+    sc_target: f64,
+    sc_weight: f64,
+    log2_rw_weight: f64,
+) -> f64 {
+    let primary = |(tc, _, rw): (f64, f64, f64)| {
+        if log2_rw_weight > f64::NEG_INFINITY {
+            fast_log2sumexp2(tc, log2_rw_weight + rw)
+        } else {
+            tc
+        }
+    };
+    let mut d_energy = primary(after) - primary(before);
+    if before.1.max(after.1) > sc_target {
+        d_energy += sc_weight * (after.1 - before.1);
+    }
+    d_energy
+}
+
 /// Optimize a subtree recursively using simulated annealing (in-place mutation).
 /// Matches Julia's `optimize_subtree!` exactly:
 /// 1. Try mutation at current node first
@@ -777,14 +979,18 @@ fn get_child_labels<L: Label>(nested: &NestedEinsum<L>, original_ixs: &[Vec<L>])
 ///
 /// By default this runs the full pipeline: structural simplification
 /// ([`crate::preprocess::simplify`]), the annealing trial loop on the reduced
-/// network, and splice-back — controlled by [`TreeSA::preprocess`]. A
-/// positive [`TreeSA::surgery_iters`] then runs that many interleaved
-/// anneal–surgery rounds ([`anneal_surgery_rounds`], the paper's Algorithm 1)
-/// on the resulting tree: each round is one waist-surgery iteration followed
-/// by a full warm-started annealing pass, so it costs roughly one extra
-/// anneal per round. The best tree seen is returned, so the result is never
-/// worse than with `surgery_iters = 0`, more rounds are equal or better, and
-/// the whole thing is fully deterministic (rounds are counted, never timed).
+/// network, optional interleaved anneal–surgery rounds, and splice-back —
+/// controlled by [`TreeSA::preprocess`]. A positive
+/// [`TreeSA::surgery_iters`] runs those rounds
+/// ([`anneal_surgery_rounds`], the paper's Algorithm 1) on the reduced network
+/// before splice-back: each round is one waist-surgery iteration followed by a
+/// cold specified-tree fine-tuning pass. Running surgery before splice-back is
+/// essential: the paper's FM cut
+/// search and side rebuilds operate on the simplified tensor hypergraph, not on
+/// the restored full graph. After splice-back, the candidate is compared with
+/// the rounds-off tree on the original network, so the result is never worse
+/// than with `surgery_iters = 0`. The whole pipeline is fully deterministic
+/// (rounds are counted, never timed).
 ///
 /// [`TreeSA::preprocess`] is automatically treated as disabled whenever
 /// [`TreeSA::decomposition_type`] is [`DecompositionType::Path`], even if the
@@ -792,7 +998,7 @@ fn get_child_labels<L: Label>(nested: &NestedEinsum<L>, original_ixs: &[Vec<L>])
 /// decomposition-agnostic and can turn a path decomposition into a
 /// non-path tree (see the doc comment on [`TreeSA::path`]).
 /// [`TreeSA::surgery_iters`] is skipped in exactly the same case and for the
-/// same reason: neither the surgery step nor the warm-started anneal is
+/// same reason: neither the surgery step nor the specified-tree fine tuning is
 /// path-preserving, so a `Path` config always returns the plain annealed
 /// path regardless of how many rounds were requested.
 pub fn optimize_treesa<L: Label>(
@@ -801,14 +1007,34 @@ pub fn optimize_treesa<L: Label>(
     config: &TreeSA,
 ) -> Option<NestedEinsum<L>> {
     let preprocess = config.preprocess && config.decomposition_type != DecompositionType::Path;
-    let tree = if preprocess {
+    if preprocess {
         let simplified = simplify(code, size_dict);
         let reduced = optimize_treesa_core(&simplified.code, size_dict, config)?;
-        splice(&reduced, &simplified.subtrees)
-    } else {
-        optimize_treesa_core(code, size_dict, config)?
-    };
+        if config.surgery_iters > 0 {
+            let candidate = anneal_surgery_rounds(
+                &reduced,
+                &simplified.code,
+                size_dict,
+                config,
+                config.surgery_iters,
+            )
+            .0;
+            let baseline = splice(&reduced, &simplified.subtrees);
+            let candidate = splice(&candidate, &simplified.subtrees);
+            let score_original = |tree: &NestedEinsum<L>| {
+                let cc = crate::contraction_complexity(tree, size_dict, &code.ixs);
+                config.score.evaluate(cc.tc, cc.sc, cc.rwc)
+            };
+            return Some(if score_original(&candidate) < score_original(&baseline) {
+                candidate
+            } else {
+                baseline
+            });
+        }
+        return Some(splice(&reduced, &simplified.subtrees));
+    }
 
+    let tree = optimize_treesa_core(code, size_dict, config)?;
     if config.surgery_iters > 0 && config.decomposition_type != DecompositionType::Path {
         return Some(anneal_surgery_rounds(&tree, code, size_dict, config, config.surgery_iters).0);
     }
@@ -888,6 +1114,10 @@ fn optimize_treesa_core<L: Label>(
     size_dict: &HashMap<L, usize>,
     config: &TreeSA,
 ) -> Option<NestedEinsum<L>> {
+    assert!(
+        config.surgery_probability.is_finite() && (0.0..=1.0).contains(&config.surgery_probability),
+        "surgery probability must be finite and in [0, 1]"
+    );
     if code.num_tensors() == 0 {
         return None;
     }
@@ -905,6 +1135,9 @@ fn optimize_treesa_core<L: Label>(
         .collect();
     let int_ixs = convert_to_int_indices(&code.ixs, &label_map);
     let int_iy: Vec<usize> = code.iy.iter().map(|l| label_map[l]).collect();
+    let surgery = (config.surgery_probability > 0.0
+        && config.decomposition_type == DecompositionType::Tree)
+        .then(|| WaistUpdate::new(&int_ixs, &int_iy, &log2_sizes));
 
     // Run parallel trials on a pool whose worker stacks are sized for this
     // network (issue #29). The tree walks below — conversion, complexity,
@@ -958,17 +1191,33 @@ fn optimize_treesa_core<L: Label>(
                     ),
                 };
 
-                // Optimize
-                let optimized = optimize_tree_sa(
-                    tree,
-                    &log2_sizes,
-                    &config.betas,
-                    config.niters,
-                    &config.score,
-                    config.decomposition_type,
-                    &mut rng,
-                    nedge,
-                );
+                // Optimize. A configured surgery rule replaces local sweeps at
+                // the current beta; it never starts a separate anneal.
+                let optimized = if let Some(surgery) = &surgery {
+                    optimize_tree_sa_mixed(
+                        tree,
+                        &log2_sizes,
+                        &config.betas,
+                        config.niters,
+                        &config.score,
+                        config.decomposition_type,
+                        &mut rng,
+                        nedge,
+                        surgery,
+                        config.surgery_probability,
+                    )
+                } else {
+                    optimize_tree_sa(
+                        tree,
+                        &log2_sizes,
+                        &config.betas,
+                        config.niters,
+                        &config.score,
+                        config.decomposition_type,
+                        &mut rng,
+                        nedge,
+                    )
+                };
 
                 // Convert with openedges for correct root output (issue #13) and
                 // score the trial by the tree as it will be emitted: the
@@ -1094,62 +1343,84 @@ pub fn warm_exprtree_to_nested<L: Label>(
 #[derive(Debug, Clone, PartialEq)]
 pub struct RoundsReport {
     /// Number of interleaved rounds actually executed. Smaller than the
-    /// requested `rounds` when the loop stops early (the trajectory tree
-    /// degenerated to something that cannot be annealed, e.g. a bare leaf).
+    /// requested `rounds` when the loop stops early (the incumbent tree
+    /// degenerated to something that cannot be fine-tuned, e.g. a bare leaf).
     pub rounds_run: u64,
     /// Index of the round during which the returned best tree was produced —
-    /// by either that round's surgery step or its anneal, whichever won — or
+    /// by either that round's surgery step or its fine tuner, whichever won — or
     /// [`u64::MAX`] if no round improved on the seed. It does not imply the
-    /// winner was the round's annealed tree; a pre-anneal surgery tree can be
-    /// the best of the run.
+    /// winner was produced by fine tuning; the surgery tree itself can be the
+    /// best of the run.
     pub best_round: u64,
-    /// Score of the annealed tree at the end of each executed round, in round
-    /// order. This is the trajectory trace, not a running minimum: entries may
-    /// increase, since round `r + 1` continues from round `r`'s tree even when
-    /// that tree was worse than the incumbent best.
+    /// Score of the raw fine-tuning endpoint in each executed round. This
+    /// diagnostic may increase; the endpoint is retained only if it improves
+    /// the round incumbent.
     pub round_scores: Vec<f64>,
+    /// Per-round time-complexity trace, including the raw fine-tuning endpoint
+    /// and the retained incumbent used by the next round.
+    pub round_trace: Vec<RoundTrace>,
     /// Total number of waist-surgery iterations attempted across all rounds
     /// (sum of [`crate::waist_surgery::WaistReport::surgery_calls`]).
     pub surgery_calls_total: u64,
 }
 
+/// One interleaved surgery/fine-tuning round in log2 time-complexity units.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct RoundTrace {
+    /// Zero-based round index.
+    pub round: u64,
+    /// Retained incumbent before surgery.
+    pub tc_before: f64,
+    /// Candidate after the surgery step (equal to `tc_before` if rejected).
+    pub tc_after_surgery: f64,
+    /// Raw endpoint of the cold fine-tuning pass, whether retained or rejected.
+    /// The field keeps its historical `anneal` name for artifact compatibility.
+    pub tc_after_anneal: f64,
+    /// Best of the round incumbent, surgery candidate, and all sweep
+    /// checkpoints observed during fine tuning.
+    pub tc_retained: f64,
+    /// Whether waist surgery accepted a rebuilt tree in this round.
+    pub surgery_accepted: bool,
+}
+
 /// Deterministic interleaved anneal–surgery loop (the paper's Algorithm 1).
 ///
 /// Each round applies one waist-surgery iteration
-/// ([`crate::waist_surgery::refine_capped`]) to the current trajectory tree and
-/// then runs a full warm-started simulated-annealing pass over the surgical
-/// result, using `config`'s β schedule, iteration count and score function.
+/// ([`crate::waist_surgery::refine_capped`]) to the retained incumbent and
+/// then runs a cold fine-tuning pass over the surgical result. Fine tuning uses
+/// at most 15 stratified levels from the configured schedule with `β >= 1`, at
+/// most 30 span-gated sweeps per coarse-to-fine span, and at most three
+/// deterministic serial trials. Custom schedules containing no `β >= 1` are
+/// retained verbatim.
 ///
-/// # Trajectory chaining
+/// # Incumbent ratchet
 ///
-/// The loop keeps two separate trees. The *trajectory* is what the next round
-/// anneals from: round `r + 1` always continues from round `r`'s annealed tree,
-/// **even if that tree is worse** than the best seen so far — this is what lets
-/// surgery escape a local optimum that pure annealing cannot leave.
-/// [`RoundsReport::round_scores`] records this trajectory verbatim and is
-/// therefore not monotone.
+/// Even cold fine tuning may finish at a worse tree. That endpoint is recorded in
+/// [`RoundsReport::round_scores`] and [`RoundsReport::round_trace`], but it does
+/// not replace the incumbent. Round `r + 1` starts from the best of round `r`'s
+/// input, surgery result, and best sweep checkpoint observed during fine tuning. This
+/// matches the paper's `Anneal(T, C_outer)` contract: annealing returns its
+/// best retained tree.
 ///
 /// # Never worse, monotone in `rounds`
 ///
 /// The *returned* tree is the best tree seen anywhere in the run, including the
-/// `seed` itself and each round's post-surgery, pre-anneal tree. Consequently
+/// `seed` itself and each round's post-surgery, pre-fine-tuning tree. Consequently
 /// the result is never worse than `seed`, and — because rounds are chained
 /// deterministically — running `n + 1` rounds is always equal or better than
 /// running `n`.
 ///
 /// # Configuration used
 ///
-/// Only three fields of `config` are read: [`TreeSA::betas`], [`TreeSA::niters`]
-/// and [`TreeSA::score`] (the score also ranks candidates between rounds).
-/// [`TreeSA::ntrials`], [`TreeSA::preprocess`], [`TreeSA::surgery_iters`] and
-/// [`TreeSA::decomposition_type`] are **ignored**: the loop runs a single
-/// warm-started chain rather than independent trials, takes the seed as given
-/// instead of re-running the simplify front-end, and fixes surgery at one
-/// iteration per round.
+/// Four fields of `config` are read: [`TreeSA::betas`], [`TreeSA::niters`],
+/// [`TreeSA::ntrials`] and [`TreeSA::score`]. Fine tuning caps `niters` at 30
+/// and `ntrials` at three. [`TreeSA::preprocess`], [`TreeSA::surgery_iters`]
+/// and [`TreeSA::decomposition_type`] are **ignored**: the function takes its
+/// seed and network as given and fixes surgery at one iteration per round.
 ///
 /// # Not path-preserving
 ///
-/// The annealing step always applies binary-tree moves, and waist surgery
+/// The fine-tuning step applies binary-tree moves, and waist surgery
 /// rebuilds subtrees in a way that is not path-preserving, so the returned tree
 /// is a general (tree) decomposition **regardless of
 /// `config.decomposition_type`** — passing a [`TreeSA::path`] config does not
@@ -1160,17 +1431,18 @@ pub struct RoundsReport {
 ///
 /// # Determinism
 ///
-/// Fully reproducible: round `r` anneals with `SmallRng::seed_from_u64(0xA55E + r)`
-/// and surgery is capped by iteration count with a
+/// Fully reproducible: each fine-tuning trial has a fixed seed derived from its
+/// round and trial indices, and surgery is capped by iteration count with a
 /// [`std::time::Duration::MAX`] budget, so no wall-clock deadline can ever
 /// trigger and results never depend on machine speed. Two runs with the same
 /// inputs return byte-identical trees and reports.
 ///
 /// # Cost
 ///
-/// One round costs roughly one full anneal of the network (`betas.len() *
-/// niters` sweeps) plus one waist-surgery iteration, so total time scales
-/// linearly in `rounds`.
+/// A default fine-tuning trial uses 30 sweeps at each level of a halving span
+/// ladder from `ceil(n / 30)` to 2; three serial trials therefore use 450
+/// sweeps at `n = 761`, versus 15,000 sweeps for one default cold-start trial.
+/// Total time scales linearly in `rounds`.
 ///
 /// # Panics
 ///
@@ -1213,13 +1485,27 @@ pub fn anneal_surgery_rounds<L: Label>(
         rounds_run: 0,
         best_round: u64::MAX,
         round_scores: Vec::new(),
+        round_trace: Vec::new(),
         surgery_calls_total: 0,
     };
+    let fine_betas = fine_tune_beta_schedule(&config.betas);
+    let fine_niters = config.niters.min(30);
+    let fine_trials = config.ntrials.clamp(1, 3);
     for r in 0..rounds {
-        let (t_surg, wr) = refine_capped(&trajectory, code, size_dict, std::time::Duration::MAX, 1);
+        let tc_before = crate::contraction_complexity(&trajectory, size_dict, &code.ixs).tc;
+        let incumbent_score = score_of(&trajectory);
+        let surgery_seed = 0x0000_0054_c0ff_ee00_u64.wrapping_add(r);
+        let (t_surg, wr) = refine_capped_seeded(
+            &trajectory,
+            code,
+            size_dict,
+            std::time::Duration::MAX,
+            1,
+            surgery_seed,
+        );
         report.surgery_calls_total += wr.surgery_calls;
-        // The anneal arguments are hoisted into single-line bindings so that
-        // the anneal itself is a single-line call: coverage instrumentation
+        // The fine-tuning arguments are hoisted into single-line bindings so
+        // that the call itself is on one line: coverage instrumentation
         // attributes a multi-line statement to its continuation lines, which
         // then report as unreached even though the statement runs every round.
         // Returning early (rather than breaking) out of the same-shaped match
@@ -1230,26 +1516,68 @@ pub fn anneal_surgery_rounds<L: Label>(
             None => return (best, report),
         };
         let (start, log2, nedge) = (ctx.tree, ctx.log2_sizes, ctx.nedge);
-        let mut rng = rand::rngs::SmallRng::seed_from_u64(0xA55E + r);
-        let (betas, niters, score) = (&config.betas, config.niters, &config.score);
-        let dt = DecompositionType::Tree;
-        let annealed = optimize_tree_sa(start, &log2, betas, niters, score, dt, &mut rng, nedge);
-        let cand = warm_exprtree_to_nested(&annealed, code, &ctx.labels);
+        let (betas, niters) = (&fine_betas, fine_niters);
+        let emitted_score = |candidate: &ExprTree| {
+            let nested = warm_exprtree_to_nested(candidate, code, &ctx.labels);
+            score_of(&nested)
+        };
+        let mut best_fine_tuned: Option<(NestedEinsum<L>, f64, f64, f64)> = None;
+        for trial in 0..fine_trials {
+            let seed = 0xA55E_u64 + r * fine_trials as u64 + trial as u64;
+            let mut rng = rand::rngs::SmallRng::seed_from_u64(seed);
+            let (fine_tuned, endpoint) = fine_tune_tree_sa(
+                start.clone(),
+                &log2,
+                betas,
+                niters,
+                &emitted_score,
+                &mut rng,
+                nedge,
+            );
+            let candidate = warm_exprtree_to_nested(&fine_tuned, code, &ctx.labels);
+            let candidate_score = score_of(&candidate);
+            let endpoint = warm_exprtree_to_nested(&endpoint, code, &ctx.labels);
+            let endpoint_score = score_of(&endpoint);
+            let endpoint_tc = crate::contraction_complexity(&endpoint, size_dict, &code.ixs).tc;
+            if best_fine_tuned
+                .as_ref()
+                .map_or(true, |(_, incumbent, _, _)| candidate_score < *incumbent)
+            {
+                best_fine_tuned = Some((candidate, candidate_score, endpoint_score, endpoint_tc));
+            }
+        }
+        let Some((cand, cand_score, endpoint_score, tc_after_anneal)) = best_fine_tuned else {
+            return (best, report);
+        };
         let surg_score = score_of(&t_surg);
-        if surg_score < best_score {
-            best_score = surg_score;
-            best = t_surg;
+        let tc_after_surgery = crate::contraction_complexity(&t_surg, size_dict, &code.ixs).tc;
+
+        let mut retained = trajectory;
+        let mut retained_score = incumbent_score;
+        if surg_score < retained_score {
+            retained_score = surg_score;
+            retained = t_surg;
+        }
+        if cand_score < retained_score {
+            retained_score = cand_score;
+            retained = cand;
+        }
+        if retained_score < best_score {
+            best_score = retained_score;
+            best = retained.clone();
             report.best_round = r;
         }
-        let cand_score = score_of(&cand);
-        if cand_score < best_score {
-            best_score = cand_score;
-            best = cand.clone();
-            report.best_round = r;
-        }
-        report.round_scores.push(cand_score);
+        report.round_scores.push(endpoint_score);
+        report.round_trace.push(RoundTrace {
+            round: r,
+            tc_before,
+            tc_after_surgery,
+            tc_after_anneal,
+            tc_retained: crate::contraction_complexity(&retained, size_dict, &code.ixs).tc,
+            surgery_accepted: wr.rebuild_accepts > 0,
+        });
         report.rounds_run = r + 1;
-        trajectory = cand;
+        trajectory = retained;
     }
     (best, report)
 }
@@ -1417,6 +1745,7 @@ mod tests {
                 initializer: Initializer::Random,
                 preprocess: false,
                 surgery_iters: 0,
+                surgery_probability: 0.0,
             };
             let returned = optimize_treesa(&code, &size_dict, &config).unwrap();
             let cc = contraction_complexity(&returned, &size_dict, &code.ixs);
@@ -2267,14 +2596,18 @@ mod tests {
         let config = TreeSA::default();
         assert!(config.preprocess);
         assert_eq!(config.surgery_iters, 0);
+        assert_eq!(config.surgery_probability, 0.0);
         let fast = TreeSA::fast();
         assert!(fast.preprocess);
         assert_eq!(fast.surgery_iters, 0);
+        assert_eq!(fast.surgery_probability, 0.0);
         let tuned = TreeSA::default()
             .with_preprocess(false)
-            .with_surgery_iters(30);
+            .with_surgery_iters(30)
+            .with_surgery_probability(0.05);
         assert!(!tuned.preprocess);
         assert_eq!(tuned.surgery_iters, 30);
+        assert_eq!(tuned.surgery_probability, 0.05);
     }
 
     /// Pins the preset-level preprocess contract: `TreeSA::default()` (and
@@ -2710,25 +3043,224 @@ mod tests {
         assert_eq!(format!("{a:?}"), format!("{b:?}"));
     }
 
-    /// `surgery_iters = k` must mean "run `k` interleaved anneal–surgery
-    /// rounds on the pipeline's tree", i.e. the wrapper is exactly the
-    /// composition of the `surgery_iters = 0` pipeline with
-    /// [`anneal_surgery_rounds`].
+    #[test]
+    fn test_surgery_update_rule_is_deterministic_and_valid() {
+        let code = grid_code(4, 4);
+        let sizes: HashMap<usize, usize> =
+            code.unique_labels().into_iter().map(|l| (l, 2)).collect();
+        let cfg = TreeSA::fast()
+            .with_preprocess(false)
+            .with_surgery_probability(0.05);
+        let a = optimize_treesa(&code, &sizes, &cfg).unwrap();
+        let b = optimize_treesa(&code, &sizes, &cfg).unwrap();
+        assert_eq!(format!("{a:?}"), format!("{b:?}"));
+        assert_eq!(a.leaf_count(), code.num_tensors());
+    }
+
+    #[test]
+    fn test_zero_probability_is_byte_identical_to_default() {
+        let (code, sizes) = load_benchmark_graph("petersen");
+        let base = TreeSA::fast();
+        let explicit = base.clone().with_surgery_probability(0.0);
+        let a = optimize_treesa(&code, &sizes, &base).unwrap();
+        let b = optimize_treesa(&code, &sizes, &explicit).unwrap();
+        assert_eq!(
+            crate::json::to_json_string(&a).unwrap(),
+            crate::json::to_json_string(&b).unwrap()
+        );
+    }
+
+    #[test]
+    fn test_surgery_probability_validation() {
+        for probability in [-0.01, 1.01, f64::NAN, f64::INFINITY, f64::NEG_INFINITY] {
+            let result = std::panic::catch_unwind(|| {
+                TreeSA::default().with_surgery_probability(probability)
+            });
+            assert!(
+                result.is_err(),
+                "accepted invalid probability {probability}"
+            );
+        }
+        assert_eq!(
+            TreeSA::default()
+                .with_surgery_probability(0.0)
+                .surgery_probability,
+            0.0
+        );
+        assert_eq!(
+            TreeSA::default()
+                .with_surgery_probability(1.0)
+                .surgery_probability,
+            1.0
+        );
+
+        // Public fields allow bypassing the builder, so the optimizer must
+        // enforce the same invariant at its boundary.
+        let code = EinCode::new(vec![vec![0usize], vec![0]], vec![]);
+        let sizes: HashMap<usize, usize> = [(0, 2)].into();
+        let mut config = TreeSA::fast();
+        config.surgery_probability = -0.5;
+        assert!(std::panic::catch_unwind(|| optimize_treesa(&code, &sizes, &config)).is_err());
+    }
+
+    #[test]
+    fn test_surgery_energy_uses_treesa_log2_scale() {
+        let d = surgery_energy_difference(
+            (40.0, 10.0, 30.0),
+            (41.0, 10.0, 30.0),
+            20.0,
+            1.0,
+            f64::NEG_INFINITY,
+        );
+        assert_eq!(d, 1.0);
+        assert_eq!(
+            surgery_energy_difference(
+                (41.0, 10.0, 30.0),
+                (40.0, 10.0, 30.0),
+                20.0,
+                1.0,
+                f64::NEG_INFINITY,
+            ),
+            -1.0
+        );
+
+        let with_space = surgery_energy_difference(
+            (40.0, 21.0, 30.0),
+            (40.0, 23.0, 30.0),
+            20.0,
+            1.5,
+            f64::NEG_INFINITY,
+        );
+        assert_eq!(with_space, 3.0);
+
+        let log2_rw_weight = 0.25_f64.log2();
+        let expected = fast_log2sumexp2(41.0, log2_rw_weight + 32.0)
+            - fast_log2sumexp2(40.0, log2_rw_weight + 30.0);
+        let with_rw = surgery_energy_difference(
+            (40.0, 10.0, 30.0),
+            (41.0, 10.0, 32.0),
+            20.0,
+            0.0,
+            log2_rw_weight,
+        );
+        assert!((with_rw - expected).abs() < 1e-12);
+    }
+
+    #[test]
+    fn test_probability_one_replaces_local_sweep_even_when_no_move_exists() {
+        // With every label open, the root is the waist and contains every
+        // tensor, so WaistUpdate has no nontrivial bipartition to propose.
+        // At p=1 these failed proposal attempts still replace local sweeps;
+        // they must not silently fall back to local rewrites.
+        let tree = ExprTree::node(
+            ExprTree::node(
+                ExprTree::leaf(vec![0], 0),
+                ExprTree::leaf(vec![1], 1),
+                vec![0, 1],
+            ),
+            ExprTree::node(
+                ExprTree::leaf(vec![2], 2),
+                ExprTree::leaf(vec![3], 3),
+                vec![2, 3],
+            ),
+            vec![0, 1, 2, 3],
+        );
+        let before = format!("{tree:?}");
+        let surgery = WaistUpdate::new(
+            &[vec![0], vec![1], vec![2], vec![3]],
+            &[0, 1, 2, 3],
+            &[1.0; 4],
+        );
+        let mut rng = SmallRng::seed_from_u64(11);
+        let after = optimize_tree_sa_mixed(
+            tree,
+            &[1.0; 4],
+            &[0.1, 1.0],
+            10,
+            &ScoreFunction::default(),
+            DecompositionType::Tree,
+            &mut rng,
+            4,
+            &surgery,
+            1.0,
+        );
+        assert_eq!(format!("{after:?}"), before);
+    }
+
+    #[test]
+    fn test_probability_one_commits_a_successful_surgery_proposal() {
+        let code = grid_code(4, 4);
+        let sizes: HashMap<usize, usize> =
+            code.unique_labels().into_iter().map(|l| (l, 2)).collect();
+        let seed_config = TreeSA {
+            betas: vec![1.0],
+            ntrials: 1,
+            niters: 0,
+            initializer: Initializer::Random,
+            preprocess: false,
+            ..TreeSA::fast()
+        };
+        let seed = optimize_treesa(&code, &sizes, &seed_config).unwrap();
+        let ctx = prepare_warm_anneal(&code, &sizes, &seed).unwrap();
+        let surgery = WaistUpdate::new(&code.ixs, &code.iy, &ctx.log2_sizes);
+
+        // Find a deterministic RNG stream that yields a proposal after the
+        // mixture's Bernoulli draw. At beta=0 every finite-energy proposal is
+        // accepted, so the public mixed kernel must return that exact tree.
+        for seed in 0..1024u64 {
+            let mut expected_rng = SmallRng::seed_from_u64(seed);
+            let _mixture_draw = expected_rng.random::<f64>();
+            let Some(expected) = surgery.propose(&ctx.tree, &mut expected_rng) else {
+                continue;
+            };
+            let mut actual_rng = SmallRng::seed_from_u64(seed);
+            let actual = optimize_tree_sa_mixed(
+                ctx.tree.clone(),
+                &ctx.log2_sizes,
+                &[0.0],
+                1,
+                &ScoreFunction::default(),
+                DecompositionType::Tree,
+                &mut actual_rng,
+                ctx.nedge,
+                &surgery,
+                1.0,
+            );
+            assert_eq!(format!("{actual:?}"), format!("{expected:?}"));
+            return;
+        }
+        panic!("fixture produced no waist-surgery proposal");
+    }
+
+    /// With preprocessing enabled, `surgery_iters = k` must run `k`
+    /// interleaved anneal–surgery rounds on the reduced graph and splice back
+    /// only afterward. This is the paper pipeline; running rounds on the
+    /// already-restored graph changes both the waist and FM search space.
     #[test]
     fn test_surgery_iters_runs_interleaved_rounds() {
-        // The wrapper with surgery_iters=k must equal seed-then-rounds composed by hand.
+        // The wrapper must equal simplify -> seed -> rounds -> splice composed
+        // explicitly through the public APIs.
         let (code, sizes) = load_benchmark_graph("grid_4x4");
         let base = TreeSA::fast();
-        let seed = optimize_treesa(
-            &code,
-            &sizes,
-            &TreeSA {
-                surgery_iters: 0,
-                ..base.clone()
-            },
-        )
-        .unwrap();
-        let (by_hand, _) = anneal_surgery_rounds(&seed, &code, &sizes, &base, 2);
+        let simplified = simplify(&code, &sizes);
+        let reduced_config = TreeSA {
+            preprocess: false,
+            surgery_iters: 0,
+            ..base.clone()
+        };
+        let seed = optimize_treesa(&simplified.code, &sizes, &reduced_config).unwrap();
+        let (reduced, _) = anneal_surgery_rounds(&seed, &simplified.code, &sizes, &base, 2);
+        let seed_spliced = splice(&seed, &simplified.subtrees);
+        let reduced_spliced = splice(&reduced, &simplified.subtrees);
+        let score_of = |tree: &NestedEinsum<usize>| {
+            let cc = crate::contraction_complexity(tree, &sizes, &code.ixs);
+            base.score.evaluate(cc.tc, cc.sc, cc.rwc)
+        };
+        let by_hand = if score_of(&reduced_spliced) < score_of(&seed_spliced) {
+            reduced_spliced
+        } else {
+            seed_spliced
+        };
         let wrapped = optimize_treesa(
             &code,
             &sizes,
@@ -2744,6 +3276,31 @@ mod tests {
         );
     }
 
+    #[test]
+    fn test_preprocessed_rounds_never_worse_after_splice_for_custom_score() {
+        let (code, sizes) = load_benchmark_graph("grid_4x4");
+        let score = ScoreFunction::new(1.0, 4.0, 0.5, 6.0);
+        let base_config = TreeSA {
+            score,
+            ..TreeSA::fast()
+        };
+        let baseline = optimize_treesa(&code, &sizes, &base_config).unwrap();
+        let refined = optimize_treesa(
+            &code,
+            &sizes,
+            &TreeSA {
+                surgery_iters: 3,
+                ..base_config.clone()
+            },
+        )
+        .unwrap();
+        let score_of = |tree: &NestedEinsum<usize>| {
+            let cc = crate::contraction_complexity(tree, &sizes, &code.ixs);
+            base_config.score.evaluate(cc.tc, cc.sc, cc.rwc)
+        };
+        assert!(score_of(&refined) <= score_of(&baseline));
+    }
+
     /// The rounds loop is not path-preserving, so `optimize_treesa` must skip
     /// it entirely for `DecompositionType::Path` configs: the result is
     /// byte-identical to the same config with surgery off, and still a path.
@@ -2757,7 +3314,9 @@ mod tests {
     #[test]
     fn test_path_decomposition_skips_surgery() {
         let (code, sizes) = load_benchmark_graph("grid_4x4");
-        let cfg = TreeSA::path().with_surgery_iters(2);
+        let cfg = TreeSA::path()
+            .with_surgery_iters(2)
+            .with_surgery_probability(0.05);
         let with_surgery = optimize_treesa(&code, &sizes, &cfg).unwrap();
         let without = optimize_treesa(&code, &sizes, &TreeSA::path()).unwrap();
         assert_eq!(
@@ -2765,6 +3324,20 @@ mod tests {
             crate::json::to_json_string(&without).unwrap()
         );
         assert!(with_surgery.is_path_decomposition());
+    }
+
+    #[test]
+    fn test_fine_tune_schedule_skips_hot_restart_and_is_bounded() {
+        let dense: Vec<f64> = (0..300).map(|i| 0.01 + 0.05 * i as f64).collect();
+        let fine = fine_tune_beta_schedule(&dense);
+        assert_eq!(fine.len(), 15);
+        assert!(fine.first().is_some_and(|beta| *beta >= 1.0));
+        assert_eq!(fine.last(), dense.last());
+        assert!(fine.windows(2).all(|pair| pair[0] < pair[1]));
+
+        let custom_hot = vec![0.0, 0.1, 0.9];
+        assert_eq!(fine_tune_beta_schedule(&custom_hot), custom_hot);
+        assert!(fine_tune_beta_schedule(&[]).is_empty());
     }
 
     #[test]
@@ -2784,6 +3357,7 @@ mod tests {
         let (t2, r2) = anneal_surgery_rounds(&seed, &code, &sizes, &config, 3);
         assert_eq!(r1.rounds_run, 3);
         assert_eq!(r1.round_scores.len(), 3);
+        assert_eq!(r1.round_trace.len(), 3);
         assert!(r1.best_round == u64::MAX || r1.best_round < 3);
         // Determinism: identical trees and traces
         assert_eq!(
@@ -2791,7 +3365,12 @@ mod tests {
             crate::json::to_json_string(&t2).unwrap()
         );
         assert_eq!(r1.round_scores, r2.round_scores);
+        assert_eq!(r1.round_trace, r2.round_trace);
         assert_eq!(r1.surgery_calls_total, r2.surgery_calls_total);
+        for pair in r1.round_trace.windows(2) {
+            assert_eq!(pair[1].tc_before, pair[0].tc_retained);
+            assert!(pair[1].tc_retained <= pair[1].tc_before + 1e-9);
+        }
     }
 
     #[test]
@@ -2818,13 +3397,13 @@ mod tests {
         assert!(score_of(&t3) <= score_of(&t1));
     }
 
-    /// A round's *pre-anneal* surgery tree can be the run's final winner, not
-    /// just a waypoint the following anneal improves on. The loop must
+    /// A round's *pre-fine-tuning* surgery tree can be the run's final winner,
+    /// not just a waypoint the following fine tuner improves on. The loop must
     /// therefore rank the surgery tree against the incumbent best in its own
     /// right.
     ///
     /// The instance is rigged so that only the surgery tree can win: the seed
-    /// is a deliberately bad unannealed random tree, and the round's anneal
+    /// is a deliberately bad unannealed random tree, and the round's fine tuner
     /// runs at β = 0, where the Metropolis rule accepts every move — a pure
     /// random walk that leaves the surgery tree worse than it found it. So the
     /// improvement over the seed can only have come from the surgery step, and
@@ -2843,7 +3422,7 @@ mod tests {
             ..TreeSA::fast()
         };
         let seed = optimize_treesa(&code, &sizes, &seed_cfg).unwrap();
-        // β = 0: every proposed move is accepted, so the anneal walks away
+        // β = 0: every proposed move is accepted, so fine tuning walks away
         // from whatever the surgery step handed it.
         let config = TreeSA {
             betas: vec![0.0],
@@ -2867,7 +3446,7 @@ mod tests {
         );
         assert!(
             report.round_scores[0] > score_of(&best),
-            "the β = 0 anneal must end worse than the surgery tree, leaving it \
+            "the β = 0 fine tuner must end worse than the surgery tree, leaving it \
              the only candidate that can win: {} vs {}",
             report.round_scores[0],
             score_of(&best)
@@ -2887,6 +3466,7 @@ mod tests {
         let (t, r) = anneal_surgery_rounds(&seed, &code, &sizes, &TreeSA::fast(), 2);
         assert_eq!(r.rounds_run, 0);
         assert!(r.round_scores.is_empty());
+        assert!(r.round_trace.is_empty());
         assert_eq!(t.leaf_count(), 1);
     }
 

--- a/omeco/src/treesa.rs
+++ b/omeco/src/treesa.rs
@@ -3172,12 +3172,13 @@ mod tests {
             &[1.0; 4],
         );
         let mut rng = SmallRng::seed_from_u64(11);
+        let score = ScoreFunction::default().with_rw_weight(0.25);
         let after = optimize_tree_sa_mixed(
             tree,
             &[1.0; 4],
             &[0.1, 1.0],
             10,
-            &ScoreFunction::default(),
+            &score,
             DecompositionType::Tree,
             &mut rng,
             4,
@@ -3185,6 +3186,21 @@ mod tests {
             1.0,
         );
         assert_eq!(format!("{after:?}"), before);
+    }
+
+    #[test]
+    fn test_fine_tune_builds_a_coarse_to_fine_span_ladder() {
+        let mut tree = ExprTree::leaf(Vec::new(), 0);
+        for tensor in 1..61 {
+            tree = ExprTree::node(tree, ExprTree::leaf(Vec::new(), tensor), Vec::new());
+        }
+        let mut rng = SmallRng::seed_from_u64(17);
+        let score = |candidate: &ExprTree| candidate.leaf_count() as f64;
+
+        let (best, endpoint) = fine_tune_tree_sa(tree, &[], &[], 0, &score, &mut rng, 0);
+
+        assert_eq!(best.leaf_count(), 61);
+        assert_eq!(endpoint.leaf_count(), 61);
     }
 
     #[test]

--- a/omeco/src/waist_surgery.rs
+++ b/omeco/src/waist_surgery.rs
@@ -2248,6 +2248,50 @@ mod tests {
     }
 
     #[test]
+    fn test_single_cut_move_respects_balance_outputs_and_boundaries() {
+        let ring = EinCode::new(
+            vec![vec![0usize, 3], vec![0, 1], vec![1, 2], vec![2, 3]],
+            vec![1],
+        );
+        let label_map: HashMap<usize, usize> = (0..4).map(|label| (label, label)).collect();
+        let hyper = Hyper::build(&ring, &label_map, &[1.0; 4], 4);
+        let part = vec![true, true, false, false];
+        let mut rng = SmallRng::seed_from_u64(9);
+
+        // At an exact-size balance constraint neither side may move, even
+        // though the ring has boundary tensors.
+        assert!(single_cut_move(&hyper, part.clone(), 2, 2, &mut rng).is_none());
+
+        // With slack, output label 1 is encountered but excluded from gain;
+        // one of the remaining boundary moves is still proposed.
+        assert!(single_cut_move(&hyper, part, 1, 3, &mut rng).is_some());
+
+        // Two disconnected components have no boundary tensor at this cut.
+        let disconnected = EinCode::new(
+            vec![vec![0usize], vec![0], vec![1], vec![1]],
+            Vec::<usize>::new(),
+        );
+        let hyper = Hyper::build(&disconnected, &label_map, &[1.0; 4], 4);
+        assert!(single_cut_move(&hyper, vec![true, true, false, false], 1, 3, &mut rng).is_none());
+    }
+
+    #[test]
+    fn test_attachment_and_graft_reject_disconnected_targets() {
+        let code = EinCode::new(vec![vec![0usize], vec![0]], Vec::<usize>::new());
+        let label_map: HashMap<usize, usize> = [(0, 0)].into();
+        let hyper = Hyper::build(&code, &label_map, &[1.0], 1);
+        let mut rng = SmallRng::seed_from_u64(13);
+        let leaf = ExprTree::leaf(vec![0], 0);
+
+        assert_eq!(
+            choose_attachment(&leaf, &[true, false], true, &[0], &hyper, &mut rng),
+            Some(Vec::new())
+        );
+        assert!(choose_attachment(&leaf, &[true, false], true, &[], &hyper, &mut rng).is_none());
+        assert!(graft_leaf(leaf, &[false], ExprTree::leaf(vec![0], 1)).is_none());
+    }
+
+    #[test]
     fn test_waist_update_proposal_preserves_leaf_permutation_and_interface() {
         let code = EinCode::new(
             vec![vec![0usize, 3], vec![0, 1], vec![1, 2], vec![2, 3]],

--- a/omeco/src/waist_surgery.rs
+++ b/omeco/src/waist_surgery.rs
@@ -229,6 +229,82 @@ impl Hyper {
     }
 }
 
+/// Cached, timer-free proposal state for TreeSA's global surgery update.
+///
+/// Construction is linear in the network and happens once per TreeSA trial;
+/// each proposal then moves one boundary tensor across the waist with a
+/// leaf prune-and-regraft (SPR) edit. Unaffected subtrees retain their exact
+/// topology.
+pub(crate) struct WaistUpdate {
+    code: EinCode<usize>,
+    hyper: Hyper,
+    log2_sizes: Vec<f64>,
+    label_map: HashMap<usize, usize>,
+}
+
+impl WaistUpdate {
+    pub(crate) fn new(ixs: &[Vec<usize>], iy: &[usize], log2_sizes: &[f64]) -> Self {
+        let code = EinCode::new(ixs.to_vec(), iy.to_vec());
+        let label_map: HashMap<usize, usize> = (0..log2_sizes.len()).map(|i| (i, i)).collect();
+        let hyper = Hyper::build(&code, &label_map, log2_sizes, log2_sizes.len());
+        Self {
+            code,
+            hyper,
+            log2_sizes: log2_sizes.to_vec(),
+            label_map,
+        }
+    }
+
+    /// Propose one global waist update. The proposal itself neither accepts nor
+    /// anneals; TreeSA applies its ordinary Metropolis test at the current beta.
+    pub(crate) fn propose<R: Rng>(&self, incumbent: &ExprTree, rng: &mut R) -> Option<ExprTree> {
+        let (_, a_leaves) = extract_waist(incumbent, &self.log2_sizes)?;
+        let n = self.hyper.n;
+        if a_leaves.is_empty() || a_leaves.len() >= n {
+            return None;
+        }
+        let mut current = vec![false; n];
+        for tensor in a_leaves {
+            if tensor < n {
+                current[tensor] = true;
+            }
+        }
+        let target_a = current.iter().filter(|&&side| side).count();
+        let lo = ((target_a as f64 * (1.0 - FM_SLACK)).floor() as usize).max(1);
+        let hi = ((target_a as f64 * (1.0 + FM_SLACK)).ceil() as usize).min(n - 1);
+
+        // One sampled surgery event performs one leaf-SPR move. Repeated update
+        // opportunities supply the iteration; there is no hidden FM loop.
+        let part = single_cut_move(&self.hyper, current.clone(), lo, hi, rng)?;
+        let size_a = part.iter().filter(|&&side| side).count();
+        if size_a < lo || size_a > hi {
+            return None;
+        }
+
+        let moved_tensor = current
+            .iter()
+            .zip(&part)
+            .position(|(before, after)| before != after)?;
+        let target_side = part[moved_tensor];
+        let (pruned, moved_leaf) = detach_leaf(incumbent, moved_tensor)?;
+        let attachment = choose_attachment(
+            &pruned,
+            &part,
+            target_side,
+            &self.hyper.tlabels[moved_tensor],
+            &self.hyper,
+            rng,
+        )?;
+        let grafted = graft_leaf(pruned, &attachment, moved_leaf)?;
+
+        // Re-derive every cached interface from the new topology. This is an
+        // exact normalization step, not a topology rebuild: SPR is the only
+        // structural mutation above.
+        let nested = expr_to_nested_counted(&grafted, &self.code.ixs, &self.code.iy);
+        nested_to_expr_tree(&nested, &self.label_map)
+    }
+}
+
 // =============================================================================
 // Fiduccia–Mattheyses bipartition refinement on the tensor hypergraph.
 // =============================================================================
@@ -251,12 +327,24 @@ fn gain_key(g: f64) -> u64 {
 /// partition and its straddle-cut cost.
 fn fm_refine(
     hyper: &Hyper,
-    mut part: Vec<bool>,
+    part: Vec<bool>,
     lo: usize,
     hi: usize,
     start: Instant,
     budget: Duration,
 ) -> (Vec<bool>, f64) {
+    fm_refine_core(hyper, part, lo, hi, FM_MAX_PASSES, Some((start, budget)))
+}
+
+fn fm_refine_core(
+    hyper: &Hyper,
+    mut part: Vec<bool>,
+    lo: usize,
+    hi: usize,
+    max_passes: usize,
+    deadline: Option<(Instant, Duration)>,
+) -> (Vec<bool>, f64) {
+    let out_of_time = || deadline.is_some_and(|(start, budget)| start.elapsed() >= budget);
     let n = hyper.n;
     let nlab = hyper.log2.len();
     let mut cnt_a = vec![0u32; nlab];
@@ -291,8 +379,8 @@ fn fm_refine(
 
     let mut best_cost = hyper.cut_cost(&part);
 
-    for _pass in 0..FM_MAX_PASSES {
-        if start.elapsed() >= budget {
+    for _pass in 0..max_passes {
+        if out_of_time() {
             break;
         }
         let mut gain: Vec<f64> = (0..n).map(|t| gain_of(t, &part, &cnt_a)).collect();
@@ -316,7 +404,7 @@ fn fm_refine(
         let mut improved_this_pass = false;
 
         for _step in 0..n {
-            if start.elapsed() >= budget {
+            if out_of_time() {
                 break;
             }
             // Pick max-gain unlocked feasible move.
@@ -407,6 +495,196 @@ fn fm_refine(
     (part, best_cost)
 }
 
+/// Make one bounded FM-style move across the current waist. Candidates are
+/// boundary tensors whose move respects the balance band; one of the eight
+/// highest-gain candidates is sampled to retain exploration. Whole-tree
+/// Metropolis acceptance is performed by TreeSA, not here.
+fn single_cut_move<R: Rng>(
+    hyper: &Hyper,
+    mut part: Vec<bool>,
+    lo: usize,
+    hi: usize,
+    rng: &mut R,
+) -> Option<Vec<bool>> {
+    let mut cnt_a = vec![0u32; hyper.log2.len()];
+    for (tensor, &in_a) in part.iter().enumerate() {
+        if in_a {
+            for &label in &hyper.tlabels[tensor] {
+                cnt_a[label] += 1;
+            }
+        }
+    }
+    let size_a = part.iter().filter(|&&in_a| in_a).count();
+    let mut top: Vec<(f64, usize)> = Vec::with_capacity(9);
+    for (tensor, &tensor_in_a) in part.iter().enumerate().take(hyper.n) {
+        if (tensor_in_a && size_a <= lo) || (!tensor_in_a && size_a >= hi) {
+            continue;
+        }
+        let boundary = hyper.tlabels[tensor].iter().any(|&label| {
+            let degree = hyper.label_tensors[label].len() as u32;
+            cnt_a[label] > 0 && cnt_a[label] < degree
+        });
+        if !boundary {
+            continue;
+        }
+        let mut gain = 0.0;
+        for &label in &hyper.tlabels[tensor] {
+            if hyper.is_out[label] {
+                continue;
+            }
+            let degree = hyper.label_tensors[label].len() as u32;
+            let (same, other) = if tensor_in_a {
+                (cnt_a[label], degree - cnt_a[label])
+            } else {
+                (degree - cnt_a[label], cnt_a[label])
+            };
+            gain += hyper.log2[label] * ((other >= 1) as i32 - (same >= 2) as i32) as f64;
+        }
+        top.push((gain, tensor));
+        top.sort_by(|a, b| b.0.total_cmp(&a.0).then_with(|| a.1.cmp(&b.1)));
+        top.truncate(8);
+    }
+    if top.is_empty() {
+        return None;
+    }
+    let (_, tensor) = top[rng.random_range(0..top.len())];
+    part[tensor] = !part[tensor];
+    Some(part)
+}
+
+/// Detach one leaf and suppress the unary branch left at its former parent.
+/// All other subtrees are cloned without changing their relative topology.
+fn detach_leaf(tree: &ExprTree, tensor: usize) -> Option<(ExprTree, ExprTree)> {
+    fn rec(tree: &ExprTree, tensor: usize) -> Option<(Option<ExprTree>, ExprTree)> {
+        match tree {
+            ExprTree::Leaf(info) => (info.tensor_id == Some(tensor)).then(|| (None, tree.clone())),
+            ExprTree::Node { left, right, info } => {
+                if let Some((new_left, leaf)) = rec(left, tensor) {
+                    let pruned = match new_left {
+                        Some(left) => {
+                            ExprTree::node(left, (**right).clone(), info.out_dims.clone())
+                        }
+                        None => (**right).clone(),
+                    };
+                    return Some((Some(pruned), leaf));
+                }
+                let (new_right, leaf) = rec(right, tensor)?;
+                let pruned = match new_right {
+                    Some(right) => ExprTree::node((**left).clone(), right, info.out_dims.clone()),
+                    None => (**left).clone(),
+                };
+                Some((Some(pruned), leaf))
+            }
+        }
+    }
+
+    let (pruned, leaf) = rec(tree, tensor)?;
+    Some((pruned?, leaf))
+}
+
+#[derive(Debug)]
+struct AttachmentCandidate {
+    shared_weight: f64,
+    span: usize,
+    path: Vec<bool>,
+}
+
+/// Choose a connected attachment edge wholly inside the tensor's destination
+/// side. Higher shared-index weight is preferred; smaller subtrees break ties
+/// so the edit stays local. Sampling among the top eight retains exploration.
+fn choose_attachment<R: Rng>(
+    tree: &ExprTree,
+    part: &[bool],
+    target_side: bool,
+    moved_labels: &[usize],
+    hyper: &Hyper,
+    rng: &mut R,
+) -> Option<Vec<bool>> {
+    fn visit(
+        tree: &ExprTree,
+        part: &[bool],
+        target_side: bool,
+        moved_labels: &[usize],
+        hyper: &Hyper,
+        path: &mut Vec<bool>,
+        top: &mut Vec<AttachmentCandidate>,
+    ) -> (bool, usize) {
+        let (all_target, span) = match tree {
+            ExprTree::Leaf(info) => (
+                info.tensor_id.and_then(|tensor| part.get(tensor).copied()) == Some(target_side),
+                1,
+            ),
+            ExprTree::Node { left, right, .. } => {
+                path.push(false);
+                let (left_target, left_span) =
+                    visit(left, part, target_side, moved_labels, hyper, path, top);
+                path.pop();
+                path.push(true);
+                let (right_target, right_span) =
+                    visit(right, part, target_side, moved_labels, hyper, path, top);
+                path.pop();
+                (left_target && right_target, left_span + right_span)
+            }
+        };
+
+        if all_target {
+            let shared_weight: f64 = moved_labels
+                .iter()
+                .filter(|&&label| !hyper.is_out[label] && tree.labels().contains(&label))
+                .map(|&label| hyper.log2[label])
+                .sum();
+            if shared_weight > 0.0 {
+                top.push(AttachmentCandidate {
+                    shared_weight,
+                    span,
+                    path: path.clone(),
+                });
+                top.sort_by(|a, b| {
+                    b.shared_weight
+                        .total_cmp(&a.shared_weight)
+                        .then_with(|| a.span.cmp(&b.span))
+                        .then_with(|| a.path.cmp(&b.path))
+                });
+                top.truncate(8);
+            }
+        }
+        (all_target, span)
+    }
+
+    let mut top = Vec::with_capacity(9);
+    visit(
+        tree,
+        part,
+        target_side,
+        moved_labels,
+        hyper,
+        &mut Vec::new(),
+        &mut top,
+    );
+    if top.is_empty() {
+        None
+    } else {
+        Some(top.swap_remove(rng.random_range(0..top.len())).path)
+    }
+}
+
+/// Attach `leaf` as a sibling of the subtree at `path`.
+fn graft_leaf(tree: ExprTree, path: &[bool], leaf: ExprTree) -> Option<ExprTree> {
+    if path.is_empty() {
+        return Some(ExprTree::node(tree, leaf, Vec::new()));
+    }
+    let ExprTree::Node { left, right, info } = tree else {
+        return None;
+    };
+    if path[0] {
+        let right = graft_leaf(*right, &path[1..], leaf)?;
+        Some(ExprTree::node(*left, right, info.out_dims))
+    } else {
+        let left = graft_leaf(*left, &path[1..], leaf)?;
+        Some(ExprTree::node(left, *right, info.out_dims))
+    }
+}
+
 /// Grow a connected region of `target` tensors by BFS from `seed` over the tensor
 /// adjacency; the region is side A.
 fn bfs_seed(hyper: &Hyper, seed: usize, target: usize) -> Vec<bool> {
@@ -489,7 +767,7 @@ fn node_tc(ix1: &[usize], ix2: &[usize], iy: &[usize], log2_sizes: &[f64]) -> f6
 // =============================================================================
 
 /// One span-gated SA sweep: only rewrite nodes whose leaf span is `>= min_span`.
-fn gated_sweep(
+pub(crate) fn gated_sweep(
     tree: &mut ExprTree,
     beta: f64,
     min_span: usize,
@@ -645,6 +923,33 @@ fn expr_to_nested_counted(
     rec(tree, ixs, &open_set, &global_count).0
 }
 
+fn side_open_labels(hyper: &Hyper, part: &[bool]) -> (Vec<usize>, Vec<usize>) {
+    let mut open_a = Vec::new();
+    let mut open_b = Vec::new();
+    for (label, tensors) in hyper.label_tensors.iter().enumerate() {
+        if tensors.is_empty() {
+            continue;
+        }
+        let mut in_a = false;
+        let mut in_b = false;
+        for &tensor in tensors {
+            if part[tensor] {
+                in_a = true;
+            } else {
+                in_b = true;
+            }
+        }
+        let output = hyper.is_out[label];
+        if in_a && (in_b || output) {
+            open_a.push(label);
+        }
+        if in_b && (in_a || output) {
+            open_b.push(label);
+        }
+    }
+    (open_a, open_b)
+}
+
 /// Remap the leaf tensor indices of a `NestedEinsum` through `map` (leaf i -> map[i]).
 fn remap_leaves(tree: &NestedEinsum<usize>, map: &[usize]) -> NestedEinsum<usize> {
     match tree {
@@ -791,32 +1096,7 @@ impl Refiner<'_> {
     /// Open label-ids for each side: a label is open on side A iff it occurs in A
     /// and (occurs in B or is an output label). Symmetric for B.
     fn side_open_labels(&self, part: &[bool]) -> (Vec<usize>, Vec<usize>) {
-        let nlab = self.hyper.log2.len();
-        let mut open_a = Vec::new();
-        let mut open_b = Vec::new();
-        for l in 0..nlab {
-            let ts = &self.hyper.label_tensors[l];
-            if ts.is_empty() {
-                continue;
-            }
-            let mut in_a = false;
-            let mut in_b = false;
-            for &t in ts {
-                if part[t] {
-                    in_a = true;
-                } else {
-                    in_b = true;
-                }
-            }
-            let out = self.hyper.is_out[l];
-            if in_a && (in_b || out) {
-                open_a.push(l);
-            }
-            if in_b && (in_a || out) {
-                open_b.push(l);
-            }
-        }
-        (open_a, open_b)
+        side_open_labels(self.hyper, part)
     }
 
     /// Solve a side sub-einsum: greedy + a fixed number of cold span-gated anneal
@@ -992,6 +1272,22 @@ pub fn refine_capped<L: Label>(
     budget: Duration,
     max_iters: u64,
 ) -> (NestedEinsum<L>, WaistReport) {
+    refine_capped_seeded(tree, code, sizes, budget, max_iters, RNG_SEED)
+}
+
+/// Iteration-capped refinement with a caller-selected deterministic RNG stream.
+///
+/// The public standalone API intentionally keeps its historical fixed seed.
+/// Interleaved TreeSA rounds use distinct seeds so repeated calls on an
+/// unchanged incumbent do not replay the identical FM/BFS proposal forever.
+pub(crate) fn refine_capped_seeded<L: Label>(
+    tree: &NestedEinsum<L>,
+    code: &EinCode<L>,
+    sizes: &HashMap<L, usize>,
+    budget: Duration,
+    max_iters: u64,
+    rng_seed: u64,
+) -> (NestedEinsum<L>, WaistReport) {
     let n = code.num_tensors();
     let mut report = WaistReport {
         n_original: n,
@@ -1055,7 +1351,7 @@ pub fn refine_capped<L: Label>(
         start: Instant::now(),
         budget,
         max_iters,
-        rng: SmallRng::seed_from_u64(RNG_SEED),
+        rng: SmallRng::seed_from_u64(rng_seed),
         report,
     };
 
@@ -1917,5 +2213,113 @@ mod tests {
         let sizes: HashMap<usize, usize> = [(0, 2), (1, 2), (2, 2), (3, 2)].into();
         let cc = contraction_complexity(&nested, &sizes, &ixs);
         assert!(cc.tc.is_finite());
+    }
+
+    #[test]
+    fn test_single_cut_move_flips_exactly_one_feasible_boundary_tensor() {
+        let code = EinCode::new(
+            vec![vec![0usize, 3], vec![0, 1], vec![1, 2], vec![2, 3]],
+            vec![],
+        );
+        let label_map: HashMap<usize, usize> = (0..4).map(|label| (label, label)).collect();
+        let hyper = Hyper::build(&code, &label_map, &[1.0; 4], 4);
+        let before = vec![true, true, false, false];
+        let mut rng = SmallRng::seed_from_u64(7);
+        let after = single_cut_move(&hyper, before.clone(), 1, 3, &mut rng)
+            .expect("ring cut has feasible boundary moves");
+
+        let changed: Vec<usize> = before
+            .iter()
+            .zip(&after)
+            .enumerate()
+            .filter_map(|(tensor, (a, b))| (a != b).then_some(tensor))
+            .collect();
+        assert_eq!(changed.len(), 1);
+        let size_a = after.iter().filter(|&&in_a| in_a).count();
+        assert!((1..=3).contains(&size_a));
+
+        let moved = changed[0];
+        let was_boundary = hyper.tlabels[moved].iter().any(|&label| {
+            let members = &hyper.label_tensors[label];
+            members.iter().any(|&tensor| before[tensor])
+                && members.iter().any(|&tensor| !before[tensor])
+        });
+        assert!(was_boundary);
+    }
+
+    #[test]
+    fn test_waist_update_proposal_preserves_leaf_permutation_and_interface() {
+        let code = EinCode::new(
+            vec![vec![0usize, 3], vec![0, 1], vec![1, 2], vec![2, 3]],
+            vec![],
+        );
+        let left = ExprTree::node(
+            ExprTree::leaf(code.ixs[0].clone(), 0),
+            ExprTree::leaf(code.ixs[2].clone(), 2),
+            vec![0, 1, 2, 3],
+        );
+        let right = ExprTree::node(
+            ExprTree::leaf(code.ixs[1].clone(), 1),
+            ExprTree::leaf(code.ixs[3].clone(), 3),
+            vec![0, 1, 2, 3],
+        );
+        let incumbent = ExprTree::node(left, right, vec![]);
+        let update = WaistUpdate::new(&code.ixs, &code.iy, &[1.0; 4]);
+        let mut rng = SmallRng::seed_from_u64(7);
+        let candidate = update
+            .propose(&incumbent, &mut rng)
+            .expect("alternating ring waist has a boundary move");
+
+        let mut leaves = candidate.leaf_ids();
+        leaves.sort_unstable();
+        assert_eq!(leaves, vec![0, 1, 2, 3]);
+        assert_eq!(candidate.labels(), code.iy);
+        let (tc, sc, rw) = tree_complexity(&candidate, &[1.0; 4]);
+        assert!(tc.is_finite() && sc.is_finite() && rw.is_finite());
+    }
+
+    #[test]
+    fn test_leaf_spr_preserves_subtrees_off_the_two_edit_paths() {
+        fn pair(a: usize, b: usize) -> ExprTree {
+            ExprTree::node(
+                ExprTree::leaf(vec![a], a),
+                ExprTree::leaf(vec![b], b),
+                vec![a, b],
+            )
+        }
+        fn subtree_at<'a>(tree: &'a ExprTree, path: &[bool]) -> &'a ExprTree {
+            if path.is_empty() {
+                return tree;
+            }
+            let ExprTree::Node { left, right, .. } = tree else {
+                panic!("path entered a leaf");
+            };
+            subtree_at(if path[0] { right } else { left }, &path[1..])
+        }
+
+        let before = ExprTree::node(
+            ExprTree::node(pair(0, 1), pair(2, 3), vec![0, 1, 2, 3]),
+            ExprTree::node(pair(4, 5), pair(6, 7), vec![4, 5, 6, 7]),
+            vec![],
+        );
+        let untouched_23 = format!("{:?}", subtree_at(&before, &[false, true]));
+        let untouched_67 = format!("{:?}", subtree_at(&before, &[true, true]));
+
+        let (pruned, leaf) = detach_leaf(&before, 0).expect("leaf 0 exists");
+        // After suppressing (0,1), leaf 4 remains at R-L-L.
+        let after =
+            graft_leaf(pruned, &[true, false, false], leaf).expect("target attachment path exists");
+
+        assert_eq!(
+            format!("{:?}", subtree_at(&after, &[false, true])),
+            untouched_23
+        );
+        assert_eq!(
+            format!("{:?}", subtree_at(&after, &[true, true])),
+            untouched_67
+        );
+        let mut leaves = after.leaf_ids();
+        leaves.sort_unstable();
+        assert_eq!(leaves, (0..8).collect::<Vec<_>>());
     }
 }


### PR DESCRIPTION
## Summary

- treat waist surgery as an optional TreeSA update at the current temperature, without a timer, nested anneal, or cooling restart
- replace the post-surgery 300-temperature restart with deterministic cold, span-gated fine tuning and an emitted-tree incumbent ratchet
- run surgery/fine tuning on the simplified network before splice-back, then guard the final candidate against the rounds-off tree on the original network
- align Python `TreeSA()` defaults with Rust and expose `surgery_probability` consistently
- upgrade the paper artifact to format 2 and add a checked Figure 2(b) trajectory/verifier/plot

Closes #33.

## Motivation

The previous `surgery_iters` implementation restarted a full 300-temperature TreeSA anneal after every surgery. That was both expensive and algorithmically inconsistent with fine tuning an already optimized tree. It could also end at a worse tree even when an earlier surgery or fine-tuning checkpoint was better.

This change keeps the temperature schedule cold, records raw fine-tuning endpoints separately from the retained incumbent, and makes the round-level update deterministic and monotone on the supplied network. The end-to-end preprocessed pipeline additionally compares the spliced candidate with the rounds-off baseline using the original network and configured score.

## Verification

- `make check-all`: 535 passed, 1 intentional ignored performance test; 38 doctests passed, 1 ignored
- `make paper-bench-check`: exact match for 17 rows across Huawei and Apple silicon
- `make paper-figure2b-check`: exact match; `tc = 47.678726 < 47.824`, 3 accepted rebuild drops, 13 uphill raw endpoints, 32 rounds
- `make build-book`: passed
- independent implementation review: no remaining Critical or Important findings; Git harm-signal gate passed

Huawei smoke test on four Shixin Zhang TensorCircuit cases (`rounds = 8`):

| instance | TreeSA tc | rounds tc | gain | TreeSA time | rounds time |
|---|---:|---:|---:|---:|---:|
| square amplitude | 68.588445 | 61.431531 | +7.156914 | 20.4 s | 28.4 s |
| QAOA 4-regular | 43.064787 | 42.460028 | +0.604759 | 31.4 s | 44.7 s |
| 6,492-tensor MPO control | 34.589313 | 34.579349 | +0.009964 | 296.9 s | 471.9 s |
| MERA control | 13.446566 | 13.445532 | +0.001034 | 1.1 s | 1.2 s |

All four retained trajectories were monotone. Compared with the old eight-round implementation, square improves by another 2.3815 bits and QAOA by 0.0767 bits.

The final 13-instance paper set improves 13/13 cases: mean +9.9065 bits, median +4.7507, maximum +50.5857. Summed rounds-arm time is 932.4 s versus 611.0 s for plain TreeSA (+52.6%), rather than a full anneal after each round. The Huawei artifact run produced 40 rows in 1544.1 s.

## Compatibility and risk

- The new probabilistic rule defaults to `0.0`, so Rust TreeSA runs that do not opt in preserve the old RNG stream; a byte-identity test pins this.
- `surgery_iters > 0` intentionally changes behavior and artifacts: it now uses cold fine tuning and returns a retained incumbent instead of the raw endpoint of repeated hot restarts.
- Python's default beta schedule changes to the Rust default, resolving #33.
- Path decompositions skip both surgery mechanisms because neither preserves the path invariant.
- The paper benchmark schema changes from format 1 to format 2 so old and new curve meanings cannot be compared silently.

Rollback is a normal revert of this squash commit; the default-off update rule leaves no stored-state migration.
