### PR TITLE
chore(benchmarks): machine-enforce origin/master provenance gate for paper benchmarks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,8 @@ jobs:
           python-version: "3.12"
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
+      - name: Test paper master gate
+        run: make paper-master-gate-test
       - name: Verify committed benchmark artifact (ci set)
         run: make paper-bench-check
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .DEFAULT_GOAL := help
-.PHONY: help build build-release check fmt fmt-check clippy test check-all clean doc doc-private serve-docs python-dev python-dev-debug python-build python-test benchmark paper-bench paper-bench-check paper-figure2b-check paper-figure2b-plot version bump-patch bump-minor bump-major release publish publish-crates publish-all github-release install-mdbook build-book serve-book clean-book
+.PHONY: help build build-release check fmt fmt-check clippy test check-all clean doc doc-private serve-docs python-dev python-dev-debug python-build python-test benchmark paper-bench paper-bench-check paper-master-gate-test paper-figure2b-check paper-figure2b-plot version bump-patch bump-minor bump-major release publish publish-crates publish-all github-release install-mdbook build-book serve-book clean-book
 
 CARGO ?= cargo
 PYTHON ?= python3
@@ -10,6 +10,8 @@ DOC_CRATE ?= omeco
 # Paper benchmark runner (see benchmarks/paper/README.md); run from the repo root
 PAPER_BENCH = $(CARGO) run --release --example paper_bench -p omeco -- \
 	--manifest benchmarks/paper/manifest.json
+PAPER_MASTER = $(PYTHON) benchmarks/paper/run_master.py \
+	--manifest benchmarks/paper/manifest.json --cargo $(CARGO)
 
 # Extract current version from omeco/Cargo.toml
 VERSION := $(shell grep -m1 '^version' omeco/Cargo.toml | sed 's/.*"\(.*\)"/\1/')
@@ -44,6 +46,7 @@ help:
 	@printf "  benchmark         Run Python vs Julia benchmark\n"
 	@printf "  paper-bench       Regenerate the committed full paper benchmark artifact\n"
 	@printf "  paper-bench-check Re-run the ci set and verify it against the committed artifact\n"
+	@printf "  paper-master-gate-test Test the master revision and provenance gate\n"
 	@printf "  paper-figure2b-check Reproduce the Figure 2(b) surface-code trajectory\n"
 	@printf "  paper-figure2b-plot  Render the committed Figure 2(b) trajectory as SVG\n"
 	@printf "\nRelease targets:\n"
@@ -120,12 +123,15 @@ benchmark: python-dev
 # `paper-bench-check` re-runs the small ci set and compares it against the
 # committed artifact. The temporary artifact goes to $TMPDIR, never a fixed path.
 paper-bench:
-	$(PAPER_BENCH) --set full --out benchmarks/paper/expected/full.json
+	$(PAPER_MASTER) --set full --out benchmarks/paper/expected/full.json
 
 paper-bench-check:
 	@tmp=$$(mktemp) && trap 'rm -f "$$tmp"' EXIT && \
 	$(PAPER_BENCH) --set ci --out "$$tmp" && \
 	$(PYTHON) benchmarks/paper/check.py "$$tmp" benchmarks/paper/expected/ci.json
+
+paper-master-gate-test:
+	$(PYTHON) -m unittest discover -s benchmarks/paper -p 'test_*.py' -v
 
 paper-figure2b-check:
 	@tmp=$$(mktemp) && trap 'rm -f "$$tmp"' EXIT && \

--- a/benchmarks/paper/README.md
+++ b/benchmarks/paper/README.md
@@ -22,7 +22,7 @@ the run's recorded binary and input manifest. Results from a historical pin,
 research branch, attempt worktree, patched source tree, or stale local `master`
 are not paper data.
 
-Before a paper run, fetch and verify the revision:
+`run_master.py` enforces this gate. Its checks are equivalent to:
 
 ```bash
 git fetch origin master
@@ -32,13 +32,13 @@ test -z "$(git status --porcelain)" \
     || { echo "working tree is not clean" >&2; exit 1; }
 ```
 
-Record `git rev-parse HEAD`, the benchmark binary hash, the manifest hash, and
-the output alongside every run. If benchmark code, manifests, or instance data
-on `origin/master` change, the paper artifacts are stale and must be recomputed
-before manuscript numbers or figures are updated. A later documentation-only
-or artifact-only commit does not invalidate an unchanged recorded binary and
-input manifest. Revision mismatch at run time is a hard failure; there is no
-fallback to archived campaign data.
+The wrapper builds the runner and records the revision plus binary, manifest,
+selected-input, and output hashes in `<output>.provenance.json`. If benchmark
+code, manifests, or instance data on `origin/master` change, the paper artifacts
+are stale and must be recomputed before manuscript numbers or figures are
+updated. A later documentation-only or artifact-only commit does not invalidate
+an unchanged recorded binary and input manifest. Revision mismatch at run time
+is a hard failure; there is no fallback to archived campaign data.
 
 This directory is self-contained — manifest, instances, checker:
 
@@ -49,6 +49,8 @@ This directory is self-contained — manifest, instances, checker:
 | `expected/ci.json` | The `ci` set's output, re-derived and compared by `make paper-bench-check` (and by CI). `expected/full.json` is what `make paper-bench` writes. |
 | `expected/figure2b.json` | The 32-round surface-code reproduction, checked numerically and by the Figure 2(b) semantic contract. |
 | `expected/figure2b.svg` | Static fixed-work rendering of that JSON: retained incumbent, raw fine-tuning endpoints, and accepted rebuilds. |
+| `run_master.py` | Enforces current clean `origin/master`, builds the runner, and emits deterministic provenance. |
+| `test_run_master.py` | Unit tests for revision, cleanliness, tracking, hashing, and atomic-write behavior. |
 | `check.py` | Compares two artifacts and exits nonzero on any disagreement. Standard library only, Python 3.8+. |
 | `verify_figure2b.py` | Verifies the record crossing, incumbent ratchet, and accepted-rebuild mechanism. |
 | `plot_figure2b.py` | Renders the checked JSON as a dependency-free vector figure. |
@@ -85,48 +87,48 @@ with integer labels. `description` records where each network came from.
 From the repository root:
 
 ```bash
-# Small set: the one CI runs on every push (under a minute on a modern laptop).
-cargo run --release --example paper_bench -p omeco -- \
-    --manifest benchmarks/paper/manifest.json \
+# Small master set.
+python3 benchmarks/paper/run_master.py \
     --set ci \
     --out ci.json
 
-# The paper's set. ~21 min on an Apple-silicon laptop; the large instances dominate.
-cargo run --release --example paper_bench -p omeco -- \
-    --manifest benchmarks/paper/manifest.json \
+# The paper's full set; the large instances dominate.
+python3 benchmarks/paper/run_master.py \
     --set full \
     --out full.json
 
 # Figure 2(b): deterministic surfacecode_d21 trajectory (32 rounds).
-cargo run --release --example paper_bench -p omeco -- \
-    --manifest benchmarks/paper/manifest.json \
+python3 benchmarks/paper/run_master.py \
     --set figure2b \
     --out figure2b.json
 python3 benchmarks/paper/verify_figure2b.py figure2b.json
 python3 benchmarks/paper/plot_figure2b.py figure2b.json figure2b.svg
 ```
 
-Flags:
+The wrapper defaults to `benchmarks/paper/manifest.json` and the repository
+root. Its flags are:
 
-- `--manifest <file>` — manifest to read (required).
+- `--manifest <file>` — tracked manifest to read.
 - `--set <name>` — set within the manifest, `ci`, `figure2b`, or `full` (required).
 - `--out <file>` — where to write the JSON artifact (required).
 - `--repo-root <dir>` — root that instance paths in the manifest resolve
-  against. Defaults to `.`, so the commands above must be run from the
-  repository root; pass it explicitly to run from elsewhere.
+  against; every selected instance must remain inside and tracked by this
+  checkout.
+- `--cargo <path>` — Cargo executable; defaults to `$CARGO`, then `cargo`.
 
-Progress goes to stderr, the artifact to `--out`. Anything the user can get
-wrong — an unknown flag, a missing instance file, malformed JSON, a mistyped
-manifest key — prints a message naming the problem and exits with status **2**.
-The runner never reports a typo by silently falling back to a default.
+The wrapper writes the artifact to `--out` and the provenance sidecar to
+`<out>.provenance.json`. It publishes neither file from a failed run. The
+underlying Rust runner remains directly available for CI regression checks and
+development, but its ungated output is not paper data.
 
-Four Make targets wrap the same commands:
+Five Make targets wrap the benchmark workflow:
 
 ```bash
 make paper-bench-check  # ci set -> a temporary file -> check.py against expected/ci.json
+make paper-master-gate-test  # unit-test the revision/provenance gate
 make paper-figure2b-check  # 32 rounds -> semantic verifier + exact artifact check
 make paper-figure2b-plot   # committed JSON -> publication-ready static SVG
-make paper-bench        # full set -> expected/full.json (~21 min, see below)
+make paper-bench        # gated full set -> expected/full.json + provenance
 ```
 
 To compare two artifacts:

--- a/benchmarks/paper/README.md
+++ b/benchmarks/paper/README.md
@@ -24,14 +24,16 @@ Before a paper run, fetch and verify the revision:
 ```bash
 git fetch origin master
 test "$(git rev-parse HEAD)" = "$(git rev-parse origin/master)"
-test -z "$(git status --porcelain --untracked-files=no)"
+test -z "$(git status --porcelain)"
 ```
 
 Record `git rev-parse HEAD`, the benchmark binary hash, the manifest hash, and
-the output alongside every run. If `origin/master` moves, the paper artifacts
-are stale and must be recomputed before manuscript numbers or figures are
-updated. Revision mismatch is a hard failure; there is no fallback to archived
-campaign data.
+the output alongside every run. If benchmark code, manifests, or instance data
+on `origin/master` change, the paper artifacts are stale and must be recomputed
+before manuscript numbers or figures are updated. A later documentation-only
+or artifact-only commit does not invalidate an unchanged recorded binary and
+input manifest. Revision mismatch at run time is a hard failure; there is no
+fallback to archived campaign data.
 
 This directory is self-contained — manifest, instances, checker:
 
@@ -53,12 +55,11 @@ surface.
 
 ### Instance provenance
 
-`instances/*.json` are copied verbatim from `research/benchmark/targets/` on the
-research branch (`jg/autoresearch`), which is where the paper campaign draws its
-inputs from; the campaign and this benchmark therefore run on the same bytes.
-They live here rather than being referenced across branches so that a checkout
-of this branch alone can reproduce the paper — a benchmark that only runs if you
-also happen to have some other branch checked out is not reproducible.
+`instances/*.json` were copied verbatim from `research/benchmark/targets/` when
+the artifact was assembled. The copies committed on `master` are now canonical:
+a paper run never reads an instance from a research branch. They live here so a
+checkout of `master` alone reproduces the paper — a benchmark that also needs
+some other branch is not reproducible.
 
 The one exception is `petersen`, which is read from the library's own
 `benchmarks/graphs/petersen.json`: it is a shared fixture the rest of the test

--- a/benchmarks/paper/README.md
+++ b/benchmarks/paper/README.md
@@ -1,19 +1,37 @@
 # Paper benchmark artifact
 
 Every number in the paper's released-artifact table is produced here, by the
-released library, on the reader's own machine. There is no reference host and no
-recorded oracle: the artifact is a *program plus a manifest*, and reproducing
-that table means running it. The `figure2b` set separately reproduces the
-surface-code mechanism panel with a deterministic 32-round work budget: it
-must cross the panel's pre-surgery record and show an accepted rebuild causing
-a drop. It must also expose at least one uphill fine-tuning endpoint separately
-from the monotone retained incumbent. The broader headline campaign remains a
-wall-clock-budgeted measurement on one fixed host; see
-[Calibration vs the frozen campaign](#calibration-vs-the-frozen-campaign) for
-the size of the gap and why it is there. The outputs under `expected/` are committed only so that
-they can be *re-derived* — CI regenerates the `ci` one on every push and fails on
-a single changed field, so a committed number can never quietly drift away from
-what the code does.
+current `master` library, on the reader's own machine. There is no reference
+host and no recorded oracle: the artifact is a *program plus a manifest*, and
+reproducing that table means running it. The `figure2b` set separately
+reproduces the surface-code mechanism panel with a deterministic 32-round work
+budget: it must cross the panel's pre-surgery record and show an accepted
+rebuild causing a drop. It must also expose at least one uphill fine-tuning
+endpoint separately from the monotone retained incumbent. The outputs under
+`expected/` are committed only so that they can be *re-derived* — CI
+regenerates the `ci` one on every push and fails on a single changed field, so
+a committed number can never quietly drift away from what the code does.
+
+## Master revision hard gate
+
+**The paper always tracks the current `master` revision.** A result is valid for
+the paper only when it was generated from the exact commit currently at
+`origin/master`. Results from a historical pin, research branch, attempt
+worktree, patched source tree, or stale local `master` are not paper data.
+
+Before a paper run, fetch and verify the revision:
+
+```bash
+git fetch origin master
+test "$(git rev-parse HEAD)" = "$(git rev-parse origin/master)"
+test -z "$(git status --porcelain --untracked-files=no)"
+```
+
+Record `git rev-parse HEAD`, the benchmark binary hash, the manifest hash, and
+the output alongside every run. If `origin/master` moves, the paper artifacts
+are stale and must be recomputed before manuscript numbers or figures are
+updated. Revision mismatch is a hard failure; there is no fallback to archived
+campaign data.
 
 This directory is self-contained — manifest, instances, checker:
 
@@ -245,51 +263,10 @@ Adding an instance means adding a file to `instances/` and a row to the
 manifest — the runner has no instance list of its own and no discovery pass over
 the directory, so an instance nobody declared is never silently benchmarked.
 
-## Calibration vs the frozen campaign
+## Scope of the artifact
 
-The current format-2 full set took 1289.1 s (21.5 minutes) for 40 results on
-the Huawei benchmark host; the slowest single instance × arm was
-`nqueens_28`'s `treesa_rounds` at 220.7 s.
-
-The paper's headline numbers come from a wall-clock-budgeted campaign on a
-fixed host, not from this artifact. It is worth knowing how far apart the two
-are, so here are three instances side by side. Campaign values are the *best*
-`tc` recorded anywhere in the paper repository's `data/huawei_campaign.json`
-for that instance; `treesa_rounds` values are the committed `expected/full.json`
-rows produced by the `full` set (`TreeSA::default()`, `rounds: 8`).
-
-| Instance | Campaign best tc (huawei, wall-clock budget) | `treesa_rounds` tc (rounds = 8, deterministic) | Gap |
-|---|---|---|---|
-| `surfacecode_d13` | 30.485 — `p4_family["13"]`, the surface-code family sweep: 5 reps at the 90 s budget, both methods tie | 30.557 | +0.072 |
-| `surfacecode_d21` | 47.364 — `p2_budget_scaling`, our TreeSA baseline (`ref`) at the 900 s budget | 48.395 | +1.031 |
-| `ksg` | 36.356 — `p3_distributions`, best of 15 reps at the 90 s budget | 37.016 | +0.660 |
-
-(The campaign file records `tc` only, so there is no `sc` column to compare;
-this artifact's `sc` for the three rows is 24, 40 and 30 respectively.)
-
-The gaps are expected and they are not a defect. The two sides are budgeted by
-different quantities: `rounds` is a *schedule* budget — eight rounds is eight
-rounds on any machine, forever — while the campaign gave each attempt a fixed
-number of seconds on one 2-core x86 VM and took the best of many repetitions.
-A wall-clock budget buys more search on a faster host and less on a slower one,
-which is exactly the property this artifact is built to *not* have. What
-`expected/full.json` claims is bit-reproducibility: run the same commit on the
-same machine and you get the same file. Across machines the claim is weaker and
-partly untested — agreement to `1e-9` is *confirmed* across the Huawei host and
-Apple silicon for both the `ci` and `figure2b` sets. `full.json` was generated
-on Huawei and is expected to agree by the same mechanism, but its complete
-cross-platform rerun remains unchecked. The eight-round `full` set does not
-claim to reproduce a record. The 32-round `figure2b` set does cross the panel's
-47.824 pre-surgery record at 47.813971 while preserving a fixed work budget;
-it does not claim the campaign's 47.377 median.
-
-## Frozen campaign data
-
-This directory reproduces the numbers. It does not archive them. The frozen
-per-run campaign data behind the published figures — every trial's score, timing
-and provenance, far more than the summary tables show — lives with the
-manuscript, in the paper repository
-(<https://github.com/GiggleLiu/contraction-order-frontiers>, private). When a
-paper table and a fresh `paper_bench` run disagree, the paper repository says
-which library revision produced the table; this directory says what the current
-one does.
+The `full`, `figure2b`, and `ci` sets are the canonical sources for the paper's
+omeco results. Archived development campaigns may be useful for debugging or
+historical comparison, but they cannot supply manuscript numbers. When a paper
+table and a fresh current-`master` run disagree, the fresh run wins and the
+paper must be updated.

--- a/benchmarks/paper/README.md
+++ b/benchmarks/paper/README.md
@@ -14,17 +14,22 @@ a committed number can never quietly drift away from what the code does.
 
 ## Master revision hard gate
 
-**The paper always tracks the current `master` revision.** A result is valid for
-the paper only when it was generated from the exact commit currently at
-`origin/master`. Results from a historical pin, research branch, attempt
-worktree, patched source tree, or stale local `master` are not paper data.
+**The paper always tracks the current `master` revision.** A paper run must be
+made from a clean checkout of the commit currently at `origin/master`, and its
+results remain valid only while the benchmark-relevant content of
+`origin/master` — benchmark code, manifests, and instance data — still matches
+the run's recorded binary and input manifest. Results from a historical pin,
+research branch, attempt worktree, patched source tree, or stale local `master`
+are not paper data.
 
 Before a paper run, fetch and verify the revision:
 
 ```bash
 git fetch origin master
-test "$(git rev-parse HEAD)" = "$(git rev-parse origin/master)"
-test -z "$(git status --porcelain)"
+test "$(git rev-parse HEAD)" = "$(git rev-parse origin/master)" \
+    || { echo "HEAD is not at origin/master" >&2; exit 1; }
+test -z "$(git status --porcelain)" \
+    || { echo "working tree is not clean" >&2; exit 1; }
 ```
 
 Record `git rev-parse HEAD`, the benchmark binary hash, the manifest hash, and

--- a/benchmarks/paper/expected/figure2b.svg
+++ b/benchmarks/paper/expected/figure2b.svg
@@ -5,16 +5,16 @@
 <g font-family="Helvetica,Arial,sans-serif" fill="#111">
 <text x="92" y="29" font-size="20" font-weight="700">Figure 2(b) reproduction — current main</text>
 <text x="92" y="52" font-size="13" fill="#444">surfacecode_d21; deterministic 32-round work budget; TreeSA defaults</text>
-<line x1="92" y1="447.34" x2="872" y2="447.34" stroke="#e4e4e4" stroke-width="1"/>
-<text x="80" y="451.34" text-anchor="end" font-size="12">48</text>
-<line x1="92" y1="367.93" x2="872" y2="367.93" stroke="#e4e4e4" stroke-width="1"/>
-<text x="80" y="371.93" text-anchor="end" font-size="12">50</text>
-<line x1="92" y1="288.51" x2="872" y2="288.51" stroke="#e4e4e4" stroke-width="1"/>
-<text x="80" y="292.51" text-anchor="end" font-size="12">52</text>
-<line x1="92" y1="209.10" x2="872" y2="209.10" stroke="#e4e4e4" stroke-width="1"/>
-<text x="80" y="213.10" text-anchor="end" font-size="12">54</text>
-<line x1="92" y1="129.69" x2="872" y2="129.69" stroke="#e4e4e4" stroke-width="1"/>
-<text x="80" y="133.69" text-anchor="end" font-size="12">56</text>
+<line x1="92" y1="458.63" x2="872" y2="458.63" stroke="#e4e4e4" stroke-width="1"/>
+<text x="80" y="462.63" text-anchor="end" font-size="12">48</text>
+<line x1="92" y1="376.80" x2="872" y2="376.80" stroke="#e4e4e4" stroke-width="1"/>
+<text x="80" y="380.80" text-anchor="end" font-size="12">50</text>
+<line x1="92" y1="294.98" x2="872" y2="294.98" stroke="#e4e4e4" stroke-width="1"/>
+<text x="80" y="298.98" text-anchor="end" font-size="12">52</text>
+<line x1="92" y1="213.15" x2="872" y2="213.15" stroke="#e4e4e4" stroke-width="1"/>
+<text x="80" y="217.15" text-anchor="end" font-size="12">54</text>
+<line x1="92" y1="131.32" x2="872" y2="131.32" stroke="#e4e4e4" stroke-width="1"/>
+<text x="80" y="135.32" text-anchor="end" font-size="12">56</text>
 <line x1="92.00" y1="76" x2="92.00" y2="482" stroke="#f0f0f0" stroke-width="1"/>
 <text x="92.00" y="505" text-anchor="middle" font-size="12">0</text>
 <line x1="189.50" y1="76" x2="189.50" y2="482" stroke="#f0f0f0" stroke-width="1"/>
@@ -37,52 +37,50 @@
 <line x1="92" y1="482" x2="872" y2="482" stroke="#111" stroke-width="1.4"/>
 <text x="482.00" y="536" text-anchor="middle" font-size="14">completed surgery/fine-tuning rounds</text>
 <text x="23" y="279.00" text-anchor="middle" font-size="14" transform="rotate(-90 23 279.00)">contraction cost tc  [log₂ flops]</text>
-<line x1="92" y1="454.33" x2="872" y2="454.33" stroke="#222" stroke-width="1.5" stroke-dasharray="3 5"/>
-<line x1="92" y1="472.07" x2="872" y2="472.07" stroke="#cc3311" stroke-width="1.5" stroke-dasharray="9 4 2 4"/>
-<polyline points="92.00,89.90 116.38,403.03 140.75,403.80 165.12,403.92 189.50,404.17 213.88,404.17 238.25,404.44 262.62,404.84 287.00,405.16 311.38,405.71 335.75,405.71 360.12,405.88 384.50,438.09 408.88,439.98 433.25,440.25 457.62,440.80 482.00,448.39 506.38,449.12 530.75,449.76 555.12,451.20 579.50,451.88 603.88,451.97 628.25,453.04 652.62,453.20 677.00,453.82 701.38,454.28 725.75,454.28 750.12,455.30 774.50,458.39 798.88,458.39 823.25,458.39 847.62,458.39 872.00,460.09" fill="none" stroke="#0072b2" stroke-width="2.8" stroke-linejoin="round" stroke-linecap="round"/>
-<circle cx="116.38" cy="402.96" r="3.1" fill="white" stroke="#777" stroke-width="1.3"/>
-<line x1="111.38" y1="386.99" x2="121.38" y2="396.99" stroke="#cc3311" stroke-width="2.2"/>
-<line x1="111.38" y1="396.99" x2="121.38" y2="386.99" stroke="#cc3311" stroke-width="2.2"/>
-<circle cx="140.75" cy="402.78" r="3.1" fill="white" stroke="#777" stroke-width="1.3"/>
-<circle cx="165.12" cy="403.71" r="3.1" fill="white" stroke="#777" stroke-width="1.3"/>
-<circle cx="189.50" cy="403.92" r="3.1" fill="white" stroke="#777" stroke-width="1.3"/>
-<circle cx="213.88" cy="402.98" r="3.1" fill="white" stroke="#777" stroke-width="1.3"/>
-<circle cx="238.25" cy="403.69" r="3.1" fill="white" stroke="#777" stroke-width="1.3"/>
-<circle cx="262.62" cy="404.02" r="3.1" fill="white" stroke="#777" stroke-width="1.3"/>
-<circle cx="287.00" cy="404.59" r="3.1" fill="white" stroke="#777" stroke-width="1.3"/>
-<circle cx="311.38" cy="405.40" r="3.1" fill="white" stroke="#777" stroke-width="1.3"/>
-<circle cx="335.75" cy="403.73" r="3.1" fill="white" stroke="#777" stroke-width="1.3"/>
-<circle cx="360.12" cy="405.84" r="3.1" fill="white" stroke="#777" stroke-width="1.3"/>
-<circle cx="384.50" cy="437.90" r="3.1" fill="white" stroke="#777" stroke-width="1.3"/>
-<line x1="379.50" y1="421.22" x2="389.50" y2="431.22" stroke="#cc3311" stroke-width="2.2"/>
-<line x1="379.50" y1="431.22" x2="389.50" y2="421.22" stroke="#cc3311" stroke-width="2.2"/>
-<circle cx="408.88" cy="439.98" r="3.1" fill="white" stroke="#777" stroke-width="1.3"/>
-<circle cx="433.25" cy="440.25" r="3.1" fill="white" stroke="#777" stroke-width="1.3"/>
-<circle cx="457.62" cy="440.72" r="3.1" fill="white" stroke="#777" stroke-width="1.3"/>
-<circle cx="482.00" cy="448.38" r="3.1" fill="white" stroke="#777" stroke-width="1.3"/>
-<line x1="477.00" y1="442.85" x2="487.00" y2="452.85" stroke="#cc3311" stroke-width="2.2"/>
-<line x1="477.00" y1="452.85" x2="487.00" y2="442.85" stroke="#cc3311" stroke-width="2.2"/>
-<circle cx="506.38" cy="448.64" r="3.1" fill="white" stroke="#777" stroke-width="1.3"/>
-<circle cx="530.75" cy="449.76" r="3.1" fill="white" stroke="#777" stroke-width="1.3"/>
-<circle cx="555.12" cy="451.20" r="3.1" fill="white" stroke="#777" stroke-width="1.3"/>
-<circle cx="579.50" cy="450.64" r="3.1" fill="white" stroke="#777" stroke-width="1.3"/>
-<circle cx="603.88" cy="451.77" r="3.1" fill="white" stroke="#777" stroke-width="1.3"/>
-<circle cx="628.25" cy="453.04" r="3.1" fill="white" stroke="#777" stroke-width="1.3"/>
-<circle cx="652.62" cy="449.62" r="3.1" fill="white" stroke="#777" stroke-width="1.3"/>
-<circle cx="677.00" cy="453.76" r="3.1" fill="white" stroke="#777" stroke-width="1.3"/>
-<circle cx="701.38" cy="454.28" r="3.1" fill="white" stroke="#777" stroke-width="1.3"/>
-<circle cx="725.75" cy="454.28" r="3.1" fill="white" stroke="#777" stroke-width="1.3"/>
-<circle cx="750.12" cy="455.29" r="3.1" fill="white" stroke="#777" stroke-width="1.3"/>
-<circle cx="774.50" cy="458.29" r="3.1" fill="white" stroke="#777" stroke-width="1.3"/>
-<circle cx="798.88" cy="455.32" r="3.1" fill="white" stroke="#777" stroke-width="1.3"/>
-<circle cx="823.25" cy="455.38" r="3.1" fill="white" stroke="#777" stroke-width="1.3"/>
-<circle cx="847.62" cy="456.13" r="3.1" fill="white" stroke="#777" stroke-width="1.3"/>
-<circle cx="872.00" cy="458.40" r="3.1" fill="white" stroke="#777" stroke-width="1.3"/>
+<line x1="92" y1="465.83" x2="872" y2="465.83" stroke="#222" stroke-width="1.5" stroke-dasharray="3 5"/>
+<polyline points="92.00,90.32 116.38,412.97 140.75,413.77 165.12,413.89 189.50,414.15 213.88,414.15 238.25,414.42 262.62,414.84 287.00,415.17 311.38,415.73 335.75,415.73 360.12,415.91 384.50,449.10 408.88,451.05 433.25,451.33 457.62,451.89 482.00,459.71 506.38,460.47 530.75,461.12 555.12,462.61 579.50,463.31 603.88,463.41 628.25,464.50 652.62,464.67 677.00,465.31 701.38,465.78 725.75,465.78 750.12,466.83 774.50,470.01 798.88,470.01 823.25,470.01 847.62,470.01 872.00,471.77" fill="none" stroke="#0072b2" stroke-width="2.8" stroke-linejoin="round" stroke-linecap="round"/>
+<circle cx="116.38" cy="412.90" r="3.1" fill="white" stroke="#777" stroke-width="1.3"/>
+<line x1="111.38" y1="396.60" x2="121.38" y2="406.60" stroke="#cc3311" stroke-width="2.2"/>
+<line x1="111.38" y1="406.60" x2="121.38" y2="396.60" stroke="#cc3311" stroke-width="2.2"/>
+<circle cx="140.75" cy="412.71" r="3.1" fill="white" stroke="#777" stroke-width="1.3"/>
+<circle cx="165.12" cy="413.67" r="3.1" fill="white" stroke="#777" stroke-width="1.3"/>
+<circle cx="189.50" cy="413.89" r="3.1" fill="white" stroke="#777" stroke-width="1.3"/>
+<circle cx="213.88" cy="412.93" r="3.1" fill="white" stroke="#777" stroke-width="1.3"/>
+<circle cx="238.25" cy="413.65" r="3.1" fill="white" stroke="#777" stroke-width="1.3"/>
+<circle cx="262.62" cy="414.00" r="3.1" fill="white" stroke="#777" stroke-width="1.3"/>
+<circle cx="287.00" cy="414.58" r="3.1" fill="white" stroke="#777" stroke-width="1.3"/>
+<circle cx="311.38" cy="415.42" r="3.1" fill="white" stroke="#777" stroke-width="1.3"/>
+<circle cx="335.75" cy="413.70" r="3.1" fill="white" stroke="#777" stroke-width="1.3"/>
+<circle cx="360.12" cy="415.87" r="3.1" fill="white" stroke="#777" stroke-width="1.3"/>
+<circle cx="384.50" cy="448.90" r="3.1" fill="white" stroke="#777" stroke-width="1.3"/>
+<line x1="379.50" y1="431.87" x2="389.50" y2="441.87" stroke="#cc3311" stroke-width="2.2"/>
+<line x1="379.50" y1="441.87" x2="389.50" y2="431.87" stroke="#cc3311" stroke-width="2.2"/>
+<circle cx="408.88" cy="451.05" r="3.1" fill="white" stroke="#777" stroke-width="1.3"/>
+<circle cx="433.25" cy="451.33" r="3.1" fill="white" stroke="#777" stroke-width="1.3"/>
+<circle cx="457.62" cy="451.81" r="3.1" fill="white" stroke="#777" stroke-width="1.3"/>
+<circle cx="482.00" cy="459.70" r="3.1" fill="white" stroke="#777" stroke-width="1.3"/>
+<line x1="477.00" y1="454.15" x2="487.00" y2="464.15" stroke="#cc3311" stroke-width="2.2"/>
+<line x1="477.00" y1="464.15" x2="487.00" y2="454.15" stroke="#cc3311" stroke-width="2.2"/>
+<circle cx="506.38" cy="459.97" r="3.1" fill="white" stroke="#777" stroke-width="1.3"/>
+<circle cx="530.75" cy="461.12" r="3.1" fill="white" stroke="#777" stroke-width="1.3"/>
+<circle cx="555.12" cy="462.61" r="3.1" fill="white" stroke="#777" stroke-width="1.3"/>
+<circle cx="579.50" cy="462.03" r="3.1" fill="white" stroke="#777" stroke-width="1.3"/>
+<circle cx="603.88" cy="463.19" r="3.1" fill="white" stroke="#777" stroke-width="1.3"/>
+<circle cx="628.25" cy="464.50" r="3.1" fill="white" stroke="#777" stroke-width="1.3"/>
+<circle cx="652.62" cy="460.98" r="3.1" fill="white" stroke="#777" stroke-width="1.3"/>
+<circle cx="677.00" cy="465.24" r="3.1" fill="white" stroke="#777" stroke-width="1.3"/>
+<circle cx="701.38" cy="465.78" r="3.1" fill="white" stroke="#777" stroke-width="1.3"/>
+<circle cx="725.75" cy="465.78" r="3.1" fill="white" stroke="#777" stroke-width="1.3"/>
+<circle cx="750.12" cy="466.83" r="3.1" fill="white" stroke="#777" stroke-width="1.3"/>
+<circle cx="774.50" cy="469.92" r="3.1" fill="white" stroke="#777" stroke-width="1.3"/>
+<circle cx="798.88" cy="466.85" r="3.1" fill="white" stroke="#777" stroke-width="1.3"/>
+<circle cx="823.25" cy="466.92" r="3.1" fill="white" stroke="#777" stroke-width="1.3"/>
+<circle cx="847.62" cy="467.69" r="3.1" fill="white" stroke="#777" stroke-width="1.3"/>
+<circle cx="872.00" cy="470.02" r="3.1" fill="white" stroke="#777" stroke-width="1.3"/>
 <rect x="508" y="73" width="360" height="105" fill="white" fill-opacity="0.92" stroke="#bbb"/>
 <line x1="520" y1="91" x2="548" y2="91" stroke="#0072b2" stroke-width="2.8"/><text x="558" y="95" font-size="12">retained incumbent</text>
 <circle cx="534" cy="113" r="3.1" fill="white" stroke="#777" stroke-width="1.3"/><text x="558" y="117" font-size="12">raw fine-tuning endpoint</text>
 <path d="M 529 130 l 10 10 m -10 0 l 10 -10" stroke="#cc3311" stroke-width="2.2"/><text x="558" y="139" font-size="12">accepted waist rebuild</text>
 <line x1="520" y1="157" x2="548" y2="157" stroke="#222" stroke-width="1.5" stroke-dasharray="3 5"/><text x="558" y="161" font-size="12">pre-surgery record 47.824</text>
-<line x1="710" y1="157" x2="738" y2="157" stroke="#cc3311" stroke-width="1.5" stroke-dasharray="9 4 2 4"/><text x="748" y="161" font-size="12">official median 47.377</text>
 <text x="92" y="555" font-size="10" fill="#555">Source: figure2b.json; final retained tc = 47.678726</text>
 </g></svg>

--- a/benchmarks/paper/plot_figure2b.py
+++ b/benchmarks/paper/plot_figure2b.py
@@ -8,7 +8,6 @@ from pathlib import Path
 
 
 PRE_SURGERY_RECORD = 47.824
-OFFICIAL_MEDIAN = 47.377
 
 
 def fail(message: str) -> None:
@@ -33,7 +32,7 @@ def main() -> None:
     left, right, top, bottom = 92, 28, 76, 78
     plot_width = width - left - right
     plot_height = height - top - bottom
-    y_values = [rows["treesa"]["tc"], PRE_SURGERY_RECORD, OFFICIAL_MEDIAN]
+    y_values = [rows["treesa"]["tc"], PRE_SURGERY_RECORD]
     for point in curve:
         y_values.extend(
             [
@@ -92,14 +91,10 @@ def main() -> None:
         ]
     )
 
-    for value, color, dash in [
-        (PRE_SURGERY_RECORD, "#222", "3 5"),
-        (OFFICIAL_MEDIAN, "#cc3311", "9 4 2 4"),
-    ]:
-        yy = y(value)
-        svg.append(
-            f'<line x1="{left}" y1="{yy:.2f}" x2="{width-right}" y2="{yy:.2f}" stroke="{color}" stroke-width="1.5" stroke-dasharray="{dash}"/>'
-        )
+    record_y = y(PRE_SURGERY_RECORD)
+    svg.append(
+        f'<line x1="{left}" y1="{record_y:.2f}" x2="{width-right}" y2="{record_y:.2f}" stroke="#222" stroke-width="1.5" stroke-dasharray="3 5"/>'
+    )
 
     retained = [(0.0, rows["treesa"]["tc"])]
     retained.extend((point["round"] + 1.0, point["tc_retained"]) for point in curve)
@@ -131,7 +126,6 @@ def main() -> None:
             f'<circle cx="{legend_x+14}" cy="{legend_y+22}" r="3.1" fill="white" stroke="#777" stroke-width="1.3"/><text x="{legend_x+38}" y="{legend_y+26}" font-size="12">raw fine-tuning endpoint</text>',
             f'<path d="M {legend_x+9} {legend_y+39} l 10 10 m -10 0 l 10 -10" stroke="#cc3311" stroke-width="2.2"/><text x="{legend_x+38}" y="{legend_y+48}" font-size="12">accepted waist rebuild</text>',
             f'<line x1="{legend_x}" y1="{legend_y+66}" x2="{legend_x+28}" y2="{legend_y+66}" stroke="#222" stroke-width="1.5" stroke-dasharray="3 5"/><text x="{legend_x+38}" y="{legend_y+70}" font-size="12">pre-surgery record 47.824</text>',
-            f'<line x1="{legend_x+190}" y1="{legend_y+66}" x2="{legend_x+218}" y2="{legend_y+66}" stroke="#cc3311" stroke-width="1.5" stroke-dasharray="9 4 2 4"/><text x="{legend_x+228}" y="{legend_y+70}" font-size="12">official median 47.377</text>',
             f'<text x="{left}" y="{height-5}" font-size="10" fill="#555">Source: {esc(source.name)}; final retained tc = {rows["treesa_rounds"]["tc"]:.6f}</text>',
             "</g></svg>",
         ]

--- a/benchmarks/paper/run_master.py
+++ b/benchmarks/paper/run_master.py
@@ -1,0 +1,260 @@
+#!/usr/bin/env python3
+"""Run a paper benchmark from a clean, current ``origin/master`` checkout."""
+
+import argparse
+import hashlib
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+from typing import Dict, List, Sequence, Tuple
+
+
+FORMAT = 1
+REPO = Path(__file__).resolve().parents[2]
+
+
+class GateError(RuntimeError):
+    """A paper run failed its provenance gate."""
+
+
+def fail(message: str) -> None:
+    raise GateError(message)
+
+
+def command(
+    argv: Sequence[str], cwd: Path, *, capture: bool = False
+) -> subprocess.CompletedProcess:
+    try:
+        return subprocess.run(
+            list(argv),
+            cwd=str(cwd),
+            check=True,
+            capture_output=capture,
+            text=capture,
+        )
+    except FileNotFoundError as exc:
+        fail(f"command not found: {argv[0]}")
+        raise AssertionError("unreachable") from exc
+    except subprocess.CalledProcessError as exc:
+        detail = (exc.stderr or exc.stdout or "").strip() if capture else ""
+        suffix = f": {detail}" if detail else ""
+        fail(f"command failed ({' '.join(argv)}){suffix}")
+        raise AssertionError("unreachable") from exc
+
+
+def git(repo: Path, *args: str) -> str:
+    result = command(["git", *args], repo, capture=True)
+    return result.stdout.strip()
+
+
+def verify_master(repo: Path, *, fetch: bool = True) -> str:
+    if fetch:
+        command(
+            [
+                "git",
+                "fetch",
+                "--quiet",
+                "origin",
+                "+refs/heads/master:refs/remotes/origin/master",
+            ],
+            repo,
+            capture=True,
+        )
+    head = git(repo, "rev-parse", "HEAD")
+    master = git(repo, "rev-parse", "refs/remotes/origin/master")
+    if head != master:
+        fail(f"HEAD {head} is not current origin/master {master}")
+    dirty = git(repo, "status", "--porcelain", "--untracked-files=all")
+    if dirty:
+        fail(f"checkout is not clean:\n{dirty}")
+    return head
+
+
+def repo_relative(repo: Path, path: Path, label: str) -> str:
+    resolved = path.resolve()
+    try:
+        relative = resolved.relative_to(repo.resolve())
+    except ValueError:
+        fail(f"{label} is outside the master checkout: {path}")
+    return relative.as_posix()
+
+
+def require_tracked(repo: Path, paths: Sequence[str]) -> None:
+    for path in paths:
+        try:
+            command(
+                ["git", "ls-files", "--error-unmatch", "--", path],
+                repo,
+                capture=True,
+            )
+        except GateError:
+            fail(f"paper input is not tracked on master: {path}")
+
+
+def load_inputs(
+    repo: Path, manifest_path: Path, set_name: str, repo_root: Path
+) -> Tuple[str, List[Tuple[str, Path]]]:
+    manifest_rel = repo_relative(repo, manifest_path, "manifest")
+    try:
+        manifest = json.loads(manifest_path.read_text())
+    except (OSError, json.JSONDecodeError) as exc:
+        fail(f"cannot read manifest {manifest_path}: {exc}")
+    sets = manifest.get("sets")
+    if not isinstance(sets, dict) or set_name not in sets:
+        fail(f"manifest has no set {set_name!r}")
+    instances = sets[set_name].get("instances")
+    if not isinstance(instances, list) or not instances:
+        fail(f"set {set_name!r} has no instances")
+    inputs: List[Tuple[str, Path]] = []
+    seen = set()
+    for index, instance in enumerate(instances):
+        if not isinstance(instance, dict) or not isinstance(instance.get("path"), str):
+            fail(f"set {set_name!r} instance {index} has no string path")
+        path = (repo_root / instance["path"]).resolve()
+        relative = repo_relative(repo, path, f"instance {index}")
+        if relative in seen:
+            continue
+        if not path.is_file():
+            fail(f"instance does not exist: {relative}")
+        seen.add(relative)
+        inputs.append((relative, path))
+    inputs.sort(key=lambda item: item[0])
+    require_tracked(repo, [manifest_rel, *[relative for relative, _ in inputs]])
+    return manifest_rel, inputs
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    try:
+        with path.open("rb") as source:
+            for block in iter(lambda: source.read(1024 * 1024), b""):
+                digest.update(block)
+    except OSError as exc:
+        fail(f"cannot hash {path}: {exc}")
+    return digest.hexdigest()
+
+
+def input_bundle(inputs: Sequence[Tuple[str, Path]]) -> Tuple[str, List[Dict[str, str]]]:
+    digest = hashlib.sha256()
+    digest.update(b"omeco-paper-inputs-v1\0")
+    entries = []
+    for relative, path in sorted(inputs, key=lambda item: item[0]):
+        data = path.read_bytes()
+        path_bytes = relative.encode("utf-8")
+        digest.update(len(path_bytes).to_bytes(8, "big"))
+        digest.update(path_bytes)
+        digest.update(len(data).to_bytes(8, "big"))
+        digest.update(data)
+        entries.append({"path": relative, "sha256": hashlib.sha256(data).hexdigest()})
+    return digest.hexdigest(), entries
+
+
+def write_atomic(path: Path, data: bytes) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    descriptor, temporary = tempfile.mkstemp(
+        prefix=f".{path.name}.", suffix=".tmp", dir=str(path.parent)
+    )
+    try:
+        with os.fdopen(descriptor, "wb") as destination:
+            destination.write(data)
+            destination.flush()
+            os.fsync(destination.fileno())
+        os.replace(temporary, path)
+    finally:
+        try:
+            os.unlink(temporary)
+        except FileNotFoundError:
+            pass
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--manifest", default="benchmarks/paper/manifest.json", type=Path
+    )
+    parser.add_argument("--set", required=True)
+    parser.add_argument("--out", required=True, type=Path)
+    parser.add_argument("--repo-root", default=Path("."), type=Path)
+    parser.add_argument("--cargo", default=os.environ.get("CARGO", "cargo"))
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    manifest = args.manifest.resolve()
+    repo_root = args.repo_root.resolve()
+    output = args.out.resolve()
+    provenance = Path(f"{output}.provenance.json")
+    temporary_output = None
+    try:
+        revision = verify_master(REPO)
+        manifest_rel, inputs = load_inputs(REPO, manifest, args.set, repo_root)
+        manifest_hash = sha256_file(manifest)
+        inputs_hash, input_entries = input_bundle(inputs)
+
+        command(
+            [args.cargo, "build", "--release", "--example", "paper_bench", "-p", "omeco"],
+            REPO,
+        )
+        # A build script must not be able to leave source changes behind.
+        dirty = git(REPO, "status", "--porcelain", "--untracked-files=all")
+        if dirty:
+            fail(f"build changed the checkout:\n{dirty}")
+        binary = REPO / "target/release/examples/paper_bench"
+        if sys.platform == "win32":
+            binary = binary.with_suffix(".exe")
+        binary_hash = sha256_file(binary)
+
+        output.parent.mkdir(parents=True, exist_ok=True)
+        descriptor, temporary_name = tempfile.mkstemp(
+            prefix=f".{output.name}.", suffix=".tmp", dir=str(output.parent)
+        )
+        os.close(descriptor)
+        os.unlink(temporary_name)
+        temporary_output = Path(temporary_name)
+        command(
+            [
+                str(binary),
+                "--manifest",
+                str(manifest),
+                "--set",
+                args.set,
+                "--out",
+                str(temporary_output),
+                "--repo-root",
+                str(repo_root),
+            ],
+            REPO,
+        )
+        output_hash = sha256_file(temporary_output)
+        record = {
+            "format": FORMAT,
+            "revision": revision,
+            "set": args.set,
+            "binary_sha256": binary_hash,
+            "manifest": {"path": manifest_rel, "sha256": manifest_hash},
+            "inputs_sha256": inputs_hash,
+            "inputs": input_entries,
+            "output": {"path": output.name, "sha256": output_hash},
+        }
+        provenance_bytes = (json.dumps(record, indent=2, sort_keys=True) + "\n").encode()
+        os.replace(temporary_output, output)
+        temporary_output = None
+        write_atomic(provenance, provenance_bytes)
+        print(f"wrote {output}")
+        print(f"wrote {provenance}")
+    except GateError as exc:
+        raise SystemExit(f"run_master.py: FAIL: {exc}") from exc
+    finally:
+        if temporary_output is not None:
+            try:
+                temporary_output.unlink()
+            except FileNotFoundError:
+                pass
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/paper/run_master.py
+++ b/benchmarks/paper/run_master.py
@@ -102,10 +102,13 @@ def load_inputs(
         manifest = json.loads(manifest_path.read_text())
     except (OSError, json.JSONDecodeError) as exc:
         fail(f"cannot read manifest {manifest_path}: {exc}")
-    sets = manifest.get("sets")
+    sets = manifest.get("sets") if isinstance(manifest, dict) else None
     if not isinstance(sets, dict) or set_name not in sets:
         fail(f"manifest has no set {set_name!r}")
-    instances = sets[set_name].get("instances")
+    selected = sets[set_name]
+    if not isinstance(selected, dict):
+        fail(f"set {set_name!r} is not an object")
+    instances = selected.get("instances")
     if not isinstance(instances, list) or not instances:
         fail(f"set {set_name!r} has no instances")
     inputs: List[Tuple[str, Path]] = []
@@ -142,7 +145,10 @@ def input_bundle(inputs: Sequence[Tuple[str, Path]]) -> Tuple[str, List[Dict[str
     digest.update(b"omeco-paper-inputs-v1\0")
     entries = []
     for relative, path in sorted(inputs, key=lambda item: item[0]):
-        data = path.read_bytes()
+        try:
+            data = path.read_bytes()
+        except OSError as exc:
+            fail(f"cannot read paper input {path}: {exc}")
         path_bytes = relative.encode("utf-8")
         digest.update(len(path_bytes).to_bytes(8, "big"))
         digest.update(path_bytes)
@@ -150,6 +156,26 @@ def input_bundle(inputs: Sequence[Tuple[str, Path]]) -> Tuple[str, List[Dict[str
         digest.update(data)
         entries.append({"path": relative, "sha256": hashlib.sha256(data).hexdigest()})
     return digest.hexdigest(), entries
+
+
+def verify_unchanged(
+    repo: Path,
+    revision: str,
+    manifest_path: Path,
+    inputs: Sequence[Tuple[str, Path]],
+    manifest_hash: str,
+    inputs_hash: str,
+) -> None:
+    head = git(repo, "rev-parse", "HEAD")
+    if head != revision:
+        fail(f"HEAD moved during the benchmark run: {head} is not {revision}")
+    dirty = git(repo, "status", "--porcelain", "--untracked-files=all")
+    if dirty:
+        fail(f"checkout changed during the benchmark run:\n{dirty}")
+    if sha256_file(manifest_path) != manifest_hash:
+        fail(f"manifest changed during the benchmark run: {manifest_path}")
+    if input_bundle(inputs)[0] != inputs_hash:
+        fail("paper inputs changed during the benchmark run")
 
 
 def write_atomic(path: Path, data: bytes) -> None:
@@ -188,7 +214,6 @@ def main() -> None:
     repo_root = args.repo_root.resolve()
     output = args.out.resolve()
     provenance = Path(f"{output}.provenance.json")
-    temporary_output = None
     try:
         revision = verify_master(REPO)
         manifest_rel, inputs = load_inputs(REPO, manifest, args.set, repo_root)
@@ -208,52 +233,49 @@ def main() -> None:
             binary = binary.with_suffix(".exe")
         binary_hash = sha256_file(binary)
 
-        output.parent.mkdir(parents=True, exist_ok=True)
-        descriptor, temporary_name = tempfile.mkstemp(
-            prefix=f".{output.name}.", suffix=".tmp", dir=str(output.parent)
-        )
-        os.close(descriptor)
-        os.unlink(temporary_name)
-        temporary_output = Path(temporary_name)
-        command(
-            [
-                str(binary),
-                "--manifest",
-                str(manifest),
-                "--set",
-                args.set,
-                "--out",
-                str(temporary_output),
-                "--repo-root",
-                str(repo_root),
-            ],
-            REPO,
-        )
-        output_hash = sha256_file(temporary_output)
-        record = {
-            "format": FORMAT,
-            "revision": revision,
-            "set": args.set,
-            "binary_sha256": binary_hash,
-            "manifest": {"path": manifest_rel, "sha256": manifest_hash},
-            "inputs_sha256": inputs_hash,
-            "inputs": input_entries,
-            "output": {"path": output.name, "sha256": output_hash},
-        }
-        provenance_bytes = (json.dumps(record, indent=2, sort_keys=True) + "\n").encode()
-        os.replace(temporary_output, output)
-        temporary_output = None
-        write_atomic(provenance, provenance_bytes)
+        with tempfile.TemporaryDirectory(prefix="omeco-paper-run.") as scratch:
+            temporary_output = Path(scratch) / output.name
+            command(
+                [
+                    str(binary),
+                    "--manifest",
+                    str(manifest),
+                    "--set",
+                    args.set,
+                    "--out",
+                    str(temporary_output),
+                    "--repo-root",
+                    str(repo_root),
+                ],
+                REPO,
+            )
+            verify_unchanged(
+                REPO, revision, manifest, inputs, manifest_hash, inputs_hash
+            )
+            try:
+                output_bytes = temporary_output.read_bytes()
+            except OSError as exc:
+                fail(f"cannot read benchmark output {temporary_output}: {exc}")
+            output_hash = hashlib.sha256(output_bytes).hexdigest()
+            record = {
+                "format": FORMAT,
+                "revision": revision,
+                "set": args.set,
+                "binary_sha256": binary_hash,
+                "manifest": {"path": manifest_rel, "sha256": manifest_hash},
+                "inputs_sha256": inputs_hash,
+                "inputs": input_entries,
+                "output": {"path": output.name, "sha256": output_hash},
+            }
+            provenance_bytes = (
+                json.dumps(record, indent=2, sort_keys=True) + "\n"
+            ).encode()
+            write_atomic(output, output_bytes)
+            write_atomic(provenance, provenance_bytes)
         print(f"wrote {output}")
         print(f"wrote {provenance}")
     except GateError as exc:
         raise SystemExit(f"run_master.py: FAIL: {exc}") from exc
-    finally:
-        if temporary_output is not None:
-            try:
-                temporary_output.unlink()
-            except FileNotFoundError:
-                pass
 
 
 if __name__ == "__main__":

--- a/benchmarks/paper/test_run_master.py
+++ b/benchmarks/paper/test_run_master.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+"""Tests for the current-master paper benchmark gate."""
+
+import importlib.util
+import json
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+
+
+MODULE_PATH = Path(__file__).with_name("run_master.py")
+SPEC = importlib.util.spec_from_file_location("run_master", MODULE_PATH)
+assert SPEC is not None and SPEC.loader is not None
+run_master = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(run_master)
+
+
+def run(*args: str, cwd: Path) -> None:
+    subprocess.run(list(args), cwd=str(cwd), check=True, capture_output=True)
+
+
+class MasterGateTests(unittest.TestCase):
+    def make_repo(self, root: Path) -> Path:
+        remote = root / "remote.git"
+        checkout = root / "checkout"
+        run("git", "init", "--bare", str(remote), cwd=root)
+        run("git", "init", str(checkout), cwd=root)
+        run("git", "branch", "-M", "master", cwd=checkout)
+        run("git", "config", "user.email", "paper-gate@example.invalid", cwd=checkout)
+        run("git", "config", "user.name", "Paper Gate Test", cwd=checkout)
+        (checkout / "tracked.txt").write_text("tracked\n")
+        run("git", "add", "tracked.txt", cwd=checkout)
+        run("git", "commit", "-m", "initial", cwd=checkout)
+        run("git", "remote", "add", "origin", str(remote), cwd=checkout)
+        run("git", "push", "-u", "origin", "master", cwd=checkout)
+        return checkout
+
+    def test_verify_master_accepts_clean_and_rejects_untracked(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            checkout = self.make_repo(Path(directory))
+            revision = run_master.verify_master(checkout)
+            self.assertEqual(revision, run_master.git(checkout, "rev-parse", "HEAD"))
+            (checkout / "build.rs").write_text("fn main() {}\n")
+            with self.assertRaisesRegex(run_master.GateError, "not clean"):
+                run_master.verify_master(checkout, fetch=False)
+
+    def test_verify_master_rejects_non_master_head(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            checkout = self.make_repo(Path(directory))
+            (checkout / "tracked.txt").write_text("changed\n")
+            run("git", "commit", "-am", "local-only", cwd=checkout)
+            with self.assertRaisesRegex(run_master.GateError, "is not current"):
+                run_master.verify_master(checkout, fetch=False)
+
+    def test_input_bundle_is_order_independent_and_content_sensitive(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            first = root / "a.json"
+            second = root / "b.json"
+            first.write_text("a\n")
+            second.write_text("b\n")
+            inputs = [("a.json", first), ("b.json", second)]
+            digest, entries = run_master.input_bundle(inputs)
+            reverse_digest, reverse_entries = run_master.input_bundle(list(reversed(inputs)))
+            self.assertEqual(digest, reverse_digest)
+            self.assertEqual(entries, reverse_entries)
+            second.write_text("changed\n")
+            changed_digest, _ = run_master.input_bundle(inputs)
+            self.assertNotEqual(digest, changed_digest)
+
+    def test_load_inputs_requires_tracked_master_files(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            checkout = self.make_repo(Path(directory))
+            instance = checkout / "instance.json"
+            manifest = checkout / "manifest.json"
+            instance.write_text("{}\n")
+            manifest.write_text(
+                json.dumps(
+                    {
+                        "sets": {
+                            "paper": {
+                                "instances": [
+                                    {"name": "one", "path": "instance.json"}
+                                ]
+                            }
+                        }
+                    }
+                )
+            )
+            with self.assertRaisesRegex(run_master.GateError, "not tracked"):
+                run_master.load_inputs(checkout, manifest, "paper", checkout)
+            run("git", "add", "manifest.json", "instance.json", cwd=checkout)
+            run("git", "commit", "-m", "add inputs", cwd=checkout)
+            manifest_rel, inputs = run_master.load_inputs(
+                checkout, manifest, "paper", checkout
+            )
+            self.assertEqual(manifest_rel, "manifest.json")
+            self.assertEqual([path for path, _ in inputs], ["instance.json"])
+
+    def test_write_atomic_replaces_file(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            output = Path(directory) / "record.json"
+            output.write_bytes(b"old")
+            run_master.write_atomic(output, b"new\n")
+            self.assertEqual(output.read_bytes(), b"new\n")
+            self.assertEqual(list(output.parent.glob(".record.json.*.tmp")), [])
+
+    def test_cli_publishes_artifact_and_provenance(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            checkout = self.make_repo(root)
+            paper = checkout / "benchmarks/paper"
+            paper.mkdir(parents=True)
+            shutil.copyfile(MODULE_PATH, paper / "run_master.py")
+            (checkout / ".gitignore").write_text("/target/\n")
+            (checkout / "instance.json").write_text("{}\n")
+            (checkout / "manifest.json").write_text(
+                json.dumps(
+                    {
+                        "sets": {
+                            "paper": {
+                                "instances": [
+                                    {"name": "one", "path": "instance.json"}
+                                ]
+                            }
+                        }
+                    }
+                )
+            )
+            fake_cargo = checkout / "fake_cargo.py"
+            fake_cargo.write_text(
+                """#!/usr/bin/env python3
+from pathlib import Path
+
+runner = Path("target/release/examples/paper_bench")
+runner.parent.mkdir(parents=True, exist_ok=True)
+runner.write_text('''#!/usr/bin/env python3
+import json
+from pathlib import Path
+import sys
+
+args = sys.argv[1:]
+out = Path(args[args.index("--out") + 1])
+set_name = args[args.index("--set") + 1]
+out.write_text(json.dumps({"format": 2, "set": set_name, "results": []}) + "\\\\n")
+''')
+runner.chmod(0o755)
+"""
+            )
+            fake_cargo.chmod(0o755)
+            run("git", "add", ".", cwd=checkout)
+            run("git", "commit", "-m", "add paper gate fixture", cwd=checkout)
+            run("git", "push", "origin", "master", cwd=checkout)
+
+            output = root / "paper.json"
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(paper / "run_master.py"),
+                    "--manifest",
+                    str(checkout / "manifest.json"),
+                    "--set",
+                    "paper",
+                    "--out",
+                    str(output),
+                    "--repo-root",
+                    str(checkout),
+                    "--cargo",
+                    str(fake_cargo),
+                ],
+                cwd=str(checkout),
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(result.returncode, 0, result.stderr)
+            provenance = Path(f"{output}.provenance.json")
+            record = json.loads(provenance.read_text())
+            self.assertEqual(record["format"], 1)
+            self.assertEqual(record["set"], "paper")
+            self.assertEqual(record["revision"], run_master.git(checkout, "rev-parse", "HEAD"))
+            self.assertEqual(record["output"]["sha256"], run_master.sha256_file(output))
+            self.assertEqual(record["inputs"][0]["path"], "instance.json")
+            self.assertEqual(len(record["binary_sha256"]), 64)
+            self.assertEqual(len(record["manifest"]["sha256"]), 64)
+            self.assertEqual(len(record["inputs_sha256"]), 64)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/benchmarks/paper/test_run_master.py
+++ b/benchmarks/paper/test_run_master.py
@@ -22,6 +22,22 @@ def run(*args: str, cwd: Path) -> None:
     subprocess.run(list(args), cwd=str(cwd), check=True, capture_output=True)
 
 
+RUNNER_SCRIPT = """#!/usr/bin/env python3
+import json
+from pathlib import Path
+import sys
+
+args = sys.argv[1:]
+out = Path(args[args.index("--out") + 1])
+set_name = args[args.index("--set") + 1]
+out.write_text(json.dumps({"format": 2, "set": set_name, "results": []}) + "\\n")
+"""
+
+MUTATING_RUNNER_SCRIPT = RUNNER_SCRIPT + """
+Path("instance.json").write_text("mutated\\n")
+"""
+
+
 class MasterGateTests(unittest.TestCase):
     def make_repo(self, root: Path) -> Path:
         remote = root / "remote.git"
@@ -100,6 +116,20 @@ class MasterGateTests(unittest.TestCase):
             self.assertEqual(manifest_rel, "manifest.json")
             self.assertEqual([path for path, _ in inputs], ["instance.json"])
 
+    def test_load_inputs_rejects_non_object_set(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            checkout = self.make_repo(Path(directory))
+            manifest = checkout / "manifest.json"
+            manifest.write_text(json.dumps({"sets": {"paper": ["not-an-object"]}}))
+            with self.assertRaisesRegex(run_master.GateError, "not an object"):
+                run_master.load_inputs(checkout, manifest, "paper", checkout)
+
+    def test_input_bundle_rejects_unreadable_input(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            missing = Path(directory) / "missing.json"
+            with self.assertRaisesRegex(run_master.GateError, "cannot read paper input"):
+                run_master.input_bundle([("missing.json", missing)])
+
     def test_write_atomic_replaces_file(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             output = Path(directory) / "record.json"
@@ -108,74 +138,67 @@ class MasterGateTests(unittest.TestCase):
             self.assertEqual(output.read_bytes(), b"new\n")
             self.assertEqual(list(output.parent.glob(".record.json.*.tmp")), [])
 
+    def make_cli_fixture(self, root: Path, runner_script: str) -> Path:
+        checkout = self.make_repo(root)
+        paper = checkout / "benchmarks/paper"
+        paper.mkdir(parents=True)
+        shutil.copyfile(MODULE_PATH, paper / "run_master.py")
+        (checkout / ".gitignore").write_text("/target/\n")
+        (checkout / "instance.json").write_text("{}\n")
+        (checkout / "manifest.json").write_text(
+            json.dumps(
+                {
+                    "sets": {
+                        "paper": {
+                            "instances": [{"name": "one", "path": "instance.json"}]
+                        }
+                    }
+                }
+            )
+        )
+        fake_cargo = checkout / "fake_cargo.py"
+        fake_cargo.write_text(
+            "#!/usr/bin/env python3\n"
+            "from pathlib import Path\n"
+            "runner = Path('target/release/examples/paper_bench')\n"
+            "runner.parent.mkdir(parents=True, exist_ok=True)\n"
+            f"runner.write_text({runner_script!r})\n"
+            "runner.chmod(0o755)\n"
+        )
+        fake_cargo.chmod(0o755)
+        run("git", "add", ".", cwd=checkout)
+        run("git", "commit", "-m", "add paper gate fixture", cwd=checkout)
+        run("git", "push", "origin", "master", cwd=checkout)
+        return checkout
+
+    def run_cli(self, checkout: Path, output: Path) -> subprocess.CompletedProcess:
+        return subprocess.run(
+            [
+                sys.executable,
+                str(checkout / "benchmarks/paper/run_master.py"),
+                "--manifest",
+                str(checkout / "manifest.json"),
+                "--set",
+                "paper",
+                "--out",
+                str(output),
+                "--repo-root",
+                str(checkout),
+                "--cargo",
+                str(checkout / "fake_cargo.py"),
+            ],
+            cwd=str(checkout),
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+
     def test_cli_publishes_artifact_and_provenance(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
-            checkout = self.make_repo(root)
-            paper = checkout / "benchmarks/paper"
-            paper.mkdir(parents=True)
-            shutil.copyfile(MODULE_PATH, paper / "run_master.py")
-            (checkout / ".gitignore").write_text("/target/\n")
-            (checkout / "instance.json").write_text("{}\n")
-            (checkout / "manifest.json").write_text(
-                json.dumps(
-                    {
-                        "sets": {
-                            "paper": {
-                                "instances": [
-                                    {"name": "one", "path": "instance.json"}
-                                ]
-                            }
-                        }
-                    }
-                )
-            )
-            fake_cargo = checkout / "fake_cargo.py"
-            fake_cargo.write_text(
-                """#!/usr/bin/env python3
-from pathlib import Path
-
-runner = Path("target/release/examples/paper_bench")
-runner.parent.mkdir(parents=True, exist_ok=True)
-runner.write_text('''#!/usr/bin/env python3
-import json
-from pathlib import Path
-import sys
-
-args = sys.argv[1:]
-out = Path(args[args.index("--out") + 1])
-set_name = args[args.index("--set") + 1]
-out.write_text(json.dumps({"format": 2, "set": set_name, "results": []}) + "\\\\n")
-''')
-runner.chmod(0o755)
-"""
-            )
-            fake_cargo.chmod(0o755)
-            run("git", "add", ".", cwd=checkout)
-            run("git", "commit", "-m", "add paper gate fixture", cwd=checkout)
-            run("git", "push", "origin", "master", cwd=checkout)
-
+            checkout = self.make_cli_fixture(root, RUNNER_SCRIPT)
             output = root / "paper.json"
-            result = subprocess.run(
-                [
-                    sys.executable,
-                    str(paper / "run_master.py"),
-                    "--manifest",
-                    str(checkout / "manifest.json"),
-                    "--set",
-                    "paper",
-                    "--out",
-                    str(output),
-                    "--repo-root",
-                    str(checkout),
-                    "--cargo",
-                    str(fake_cargo),
-                ],
-                cwd=str(checkout),
-                check=False,
-                capture_output=True,
-                text=True,
-            )
+            result = self.run_cli(checkout, output)
             self.assertEqual(result.returncode, 0, result.stderr)
             provenance = Path(f"{output}.provenance.json")
             record = json.loads(provenance.read_text())
@@ -187,6 +210,17 @@ runner.chmod(0o755)
             self.assertEqual(len(record["binary_sha256"]), 64)
             self.assertEqual(len(record["manifest"]["sha256"]), 64)
             self.assertEqual(len(record["inputs_sha256"]), 64)
+
+    def test_cli_rejects_input_mutation_during_benchmark(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            checkout = self.make_cli_fixture(root, MUTATING_RUNNER_SCRIPT)
+            output = root / "paper.json"
+            result = self.run_cli(checkout, output)
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("changed during the benchmark run", result.stderr)
+            self.assertFalse(output.exists())
+            self.assertFalse(Path(f"{output}.provenance.json").exists())
 
 
 if __name__ == "__main__":

--- a/docs/plans/2026-08-03-paper-master-gate-design.md
+++ b/docs/plans/2026-08-03-paper-master-gate-design.md
@@ -1,0 +1,45 @@
+# Paper master gate design
+
+## Goal
+
+Paper results must come from the benchmark-relevant content on the current
+`origin/master`. Historical pins, research branches, attempt worktrees, patched
+trees, and stale local checkouts cannot supply manuscript data. Each run must
+record enough deterministic provenance to establish exactly which executable
+and inputs produced its artifact.
+
+## Master-run wrapper
+
+Add `benchmarks/paper/run_master.py` as the canonical paper-data entry point.
+It mirrors the runner's manifest, set, output, and repository-root arguments.
+Before building, it fetches `origin/master`, requires `HEAD` to equal the
+fetched remote branch, and rejects any tracked or untracked working-tree
+change. Ignored build outputs such as `target/` do not fail the check.
+
+The wrapper parses the selected manifest set, resolves its declared instance
+paths, and computes SHA-256 identities for the manifest and selected input
+bundle. It builds `paper_bench` from the verified checkout, hashes the binary,
+runs it, hashes the completed JSON artifact, and atomically writes a sibling
+`<output>.provenance.json` file. Provenance contains a schema version, producing
+revision, set name, binary hash, manifest hash, selected-input hash, and output
+hash. It contains no hostname, timestamp, or absolute path.
+
+The `paper-bench` Make target uses this wrapper. PR CI retains the existing raw
+small-set reproduction because a PR commit cannot equal `origin/master`; CI
+instead unit-tests the gate and provenance logic. A failed revision, cleanliness,
+build, benchmark, or hashing check exits nonzero and leaves no provenance file.
+
+## Figure 2(b)
+
+Remove the archived `47.377` campaign median from `plot_figure2b.py`, including
+its range contribution, horizontal line, and legend item. Keep the current-main
+pre-surgery record, retained-incumbent curve, raw fine-tuning endpoints, and
+accepted-rebuild markers. Regenerate the committed SVG and run the semantic and
+exact-artifact checks.
+
+## Existing Huawei measurements
+
+After merge, rebuild on Huawei and compare the new binary, manifest, and selected
+input hashes with those recorded for commit `41833440`. Existing numerical
+artifacts remain valid only when benchmark-relevant identities are unchanged;
+otherwise the affected sets are rerun from the new `origin/master`.

--- a/omeco/examples/paper_bench.rs
+++ b/omeco/examples/paper_bench.rs
@@ -1,10 +1,10 @@
 //! Deterministic benchmark runner behind the paper's contraction-order tables.
 //!
-//! Every number in the paper's released-artifact table regenerates from the
-//! released library with this binary — there is no reference host and no
-//! recorded oracle. (The paper's headline campaign numbers are a separate,
-//! wall-clock-budgeted measurement; see `benchmarks/paper/README.md` for how
-//! far apart the two are.) A manifest names
+//! Every number in the paper regenerates from the exact current
+//! `origin/master` revision with this binary — there is no reference host and
+//! no recorded oracle, and artifacts produced from any other revision are not
+//! paper data (see the master revision hard gate in
+//! `benchmarks/paper/README.md`). A manifest names
 //! the instance files and the optimizer *arms*; the runner writes one JSON
 //! artifact whose bytes are stable for a fixed (manifest, set, machine).
 //!


### PR DESCRIPTION
## Intent

Measure and publish only results produced by current origin/master benchmark code and inputs. Machine-enforce the paper hard gate with a canonical Python wrapper that fetches origin/master, rejects revision mismatch or any dirty tracked/untracked tree, requires tracked master manifests and instances, builds the benchmark binary, and atomically publishes the artifact with deterministic revision/binary/manifest/input/output SHA-256 provenance. Keep PR CI's raw deterministic regression check and add dedicated gate tests. Remove the archived 47.377 campaign median from the current-main Figure 2(b), retain the mechanism evidence and labeled static figure, and preserve the existing deterministic benchmark protocol. Documentation-only or artifact-only commits may retain results when benchmark-relevant hashes are unchanged.

## What Changed

- Added `benchmarks/paper/run_master.py`, a canonical gated wrapper for paper benchmark runs: it fetches origin/master, fails on revision mismatch or any dirty tracked/untracked tree, requires tracked manifests and instance files, builds the release binary, re-verifies checkout cleanliness after the run completes, and atomically publishes the artifact together with a provenance sidecar recording revision, binary, manifest, input, and output SHA-256 hashes. Malformed manifests and unreadable inputs now fail with clean `FAIL:` gate errors instead of raw tracebacks.
- Added `benchmarks/paper/test_run_master.py` (9 unit tests covering revision checks, cleanliness, tracked-input enforcement, hashing, atomic writes, CLI success, and mid-run mutation rejection) wired up via a new `make paper-master-gate-test` target and a dedicated CI step; the existing raw deterministic `paper-bench-check` regression step in PR CI is unchanged.
- Removed the archived 47.377 campaign median from the current Figure 2(b) (regenerated `figure2b.svg` retains the labeled 47.824 pre-surgery record), rewrote `benchmarks/paper/README.md` around the master-only hard gate, aligned the `paper_bench.rs` doc comments, and added the gate design doc under `docs/plans/`.

## Risk Assessment

✅ Low: The fix round cleanly closes the previously reported provenance race window (scratch-dir benchmark output plus post-run HEAD/cleanliness/hash re-verification before atomic publish) and the malformed-manifest error paths, adds targeted regression tests for both, introduces no new behavior beyond the requested hardening, and continues to satisfy every required intent criterion.

## Testing

Ran the dedicated gate test suite via the exact CI command (9/9 pass), then demonstrated the gate end-to-end in a temp remote/clone fixture: a clean master checkout produced the artifact plus a hash-verified SHA-256 provenance sidecar whose ci results match the committed expected/ci.json, while a dirty tree and a non-master HEAD were both rejected with exit 1 and no published files; also confirmed the regenerated Figure 2(b) SVG is byte-identical to the committed one with the 47.377 median removed and mechanism evidence retained (rendered PNG captured), and that CI keeps the raw deterministic regression check. All checks passed.

- Evidence: Figure 2(b) current-main rendering (47.377 median removed, mechanism evidence retained) (local file: <code>/var/folders/nn/smw2hcnx18z1l6blf_p59x740000gn/T/no-mistakes-evidence/01KZ3G9Q07CYACDJWA237HH173/figure2b.png</code>)
- Evidence: Committed Figure 2(b) SVG (byte-identical to regenerated output) (local file: <code>/var/folders/nn/smw2hcnx18z1l6blf_p59x740000gn/T/no-mistakes-evidence/01KZ3G9Q07CYACDJWA237HH173/figure2b.svg</code>)
<details>
<summary>Evidence: Provenance sidecar from successful gated run</summary>

`{"revision": "ffdf108313907cde386347414d7c153d6a029fd0", "set": "ci", "binary_sha256": "7d75d006…", "manifest": {"path": "benchmarks/paper/manifest.json", "sha256": "70bdbb55…"}, "inputs_sha256": "e22470cd…", "output": {"path": "ci.json", "sha256": "9b3c08f7…"}} — output sha256 matches shasum of the published artifact`

```text
{
  "binary_sha256": "7d75d006eefb55fb4acae2fa899ebca3afbb0b771924b8e1a825250cada3ad37",
  "format": 1,
  "inputs": [
    {
      "path": "benchmarks/graphs/petersen.json",
      "sha256": "eb1e084b8dbc01a3f00b4321a261249fdd6905260ebcb2028bcd640a26be3965"
    },
    {
      "path": "benchmarks/paper/instances/dbn_13.json",
      "sha256": "651cdc643974e145f776b89546bd9f2a9da4b8c68db5e4e2017ec98cadcb39f6"
    },
    {
      "path": "benchmarks/paper/instances/qft_27.json",
      "sha256": "1f431c13683c6399c90c48ec31f4ea1f730d40216b1ddda765e9d0d1ea4eb8be"
    },
    {
      "path": "benchmarks/paper/instances/reg3_250.json",
      "sha256": "542e211fc3ef3000812c2798dc77fd40f515e5d0663541931e2e8cfbef9da641"
    },
    {
      "path": "benchmarks/paper/instances/surfacecode_d9.json",
      "sha256": "b34c49f881f7f1bd8d37ca1def4262dfdabb27ebc47fbe34dce28a8bf8a84ef5"
    }
  ],
  "inputs_sha256": "e22470cdaf01ac65f3e3b900d2622463c3305245de0e45bc6663e4d3af94e2d5",
  "manifest": {
    "path": "benchmarks/paper/manifest.json",
    "sha256": "70bdbb55a5bcd79c2443faf51c150c6645595186571896f05791f539ffd6758d"
  },
  "output": {
    "path": "ci.json",
    "sha256": "9b3c08f706dedd214d4ae1b253dfc2b8f4449b8137ffa0d2f4100a7cd283ada7"
  },
  "revision": "ffdf108313907cde386347414d7c153d6a029fd0",
  "set": "ci"
}
```
</details>
<details>
<summary>Evidence: Gate rejection transcript (dirty tree + revision mismatch, exit 1, nothing published)</summary>

`run_master.py: FAIL: checkout is not clean:\n?? scratch.txt (exit 1)\nrun_master.py: FAIL: HEAD fc43b426… is not current origin/master ffdf1083… (exit 1)\n# no artifact or provenance file published in either case`

```text
# Gate failure paths — manual CLI transcript
# Fixture: temp bare remote seeded with branch head ffdf108 as refs/heads/master,
# fresh `git clone -b master` checkout. Commands run from the clone root.

## 1. Dirty tree (untracked file present)
$ echo scratch > scratch.txt
$ python3 benchmarks/paper/run_master.py --set ci --out /tmp/dirty.json
run_master.py: FAIL: checkout is not clean:
?? scratch.txt
$ echo $?
1
# /tmp/dirty.json and /tmp/dirty.json.provenance.json were NOT created.

## 2. HEAD is not current origin/master (local-only commit)
$ rm scratch.txt
$ git commit --allow-empty -m "local-only commit"
$ python3 benchmarks/paper/run_master.py --set ci --out /tmp/mismatch.json
run_master.py: FAIL: HEAD fc43b42612551a4f717a2ed81d72794f242323cd is not current origin/master ffdf108313907cde386347414d7c153d6a029fd0
$ echo $?
1
# /tmp/mismatch.json and /tmp/mismatch.json.provenance.json were NOT created.
```
</details>
<details>
<summary>Evidence: Gated end-to-end success transcript (clean master clone → artifact + provenance; check.py OK: 17 results)</summary>

```text
# Gated end-to-end success run — transcript (temp clean clone of master=ffdf108)
$ python3 benchmarks/paper/run_master.py --set ci --out .../ci.json
  reg3_250             treesa         1.8s
  reg3_250             treesa_rounds  2.5s
paper_bench: wrote /var/folders/nn/smw2hcnx18z1l6blf_p59x740000gn/T/omeco-paper-run.skr54jad/ci.json (17 results, 20.3s)
wrote /private/tmp/omeco-gate-demo.VzTn4q/ci.json
wrote /private/tmp/omeco-gate-demo.VzTn4q/ci.json.provenance.json

$ shasum -a 256 ci.json   # matches provenance output.sha256
9b3c08f706dedd214d4ae1b253dfc2b8f4449b8137ffa0d2f4100a7cd283ada7  ci.json

$ python3 benchmarks/paper/check.py ci.json benchmarks/paper/expected/ci.json
OK: 17 results compared
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 3 issues found → auto-fixed ✅</summary>

- ⚠️ `benchmarks/paper/run_master.py:203` - Input/manifest hashes are computed before the build, and the last working-tree cleanliness check runs immediately after `cargo build`. The benchmark run itself (~20 min for the full set) then executes with no re-verification before publish, so a tracked instance or manifest file modified after the post-build check but before/while the binary reads it yields a published provenance record whose input hashes do not match the bytes actually benchmarked. Add a final `git status --porcelain --untracked-files=all` (and optionally HEAD == origin/master) re-check after the benchmark run and before `os.replace` publishes the artifact.
- ℹ️ `benchmarks/paper/run_master.py:108` - A malformed manifest where `sets[set_name]` is not a dict raises a raw AttributeError traceback from `.get(&#34;instances&#34;)` instead of the gate&#39;s `run_master.py: FAIL: ...` GateError path; similarly `input_bundle`&#39;s `path.read_bytes()` (line 145) can raise a raw OSError. The process still exits nonzero and publishes nothing, so the gate fails safely — this only degrades the error message. Guard with `isinstance(sets[set_name], dict)` and wrap the read in the existing OSError→fail pattern.
- ℹ️ `benchmarks/paper/run_master.py:244` - The artifact and its provenance sidecar are published as two sequential atomic `os.replace` calls; a crash between lines 244 and 246 leaves a fresh output beside a stale or absent provenance file. Because provenance records the output&#39;s SHA-256, the mismatch is self-detecting, and true pairwise atomicity is impossible with a two-file sidecar design — this is an acceptable, acknowledged tradeoff, noted for the record.

🔧 Fix: Re-verify provenance post-run; fail cleanly on malformed inputs
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`make paper-master-gate-test` (exact CI command; 9 unit tests covering revision, cleanliness, tracked-input, hashing, atomic-write, CLI success, and mid-run mutation rejection — all pass)</code>
- <code>Manual end-to-end gated run: temp bare remote seeded with branch head ffdf108 as master, fresh clone, `python3 benchmarks/paper/run_master.py --set ci --out ci.json` — gate passed, real cargo release build, 17 benchmark results, artifact + provenance sidecar published; output SHA-256 in provenance independently verified with `shasum -a 256`</code>
- <code>Manual gate-rejection checks in a second clone: untracked file → `FAIL: checkout is not clean` exit 1; local-only commit → `FAIL: HEAD … is not current origin/master …` exit 1; confirmed no artifact or provenance file published in either case</code>
- <code>`python3 benchmarks/paper/check.py &lt;fresh gated ci.json&gt; benchmarks/paper/expected/ci.json` → OK: 17 results compared (deterministic protocol preserved)</code>
- <code>Regenerated Figure 2(b): `python3 benchmarks/paper/plot_figure2b.py expected/figure2b.json` → byte-identical to committed SVG; grep confirms no &#39;official median&#39;/47.377 label, pre-surgery record 47.824 retained; rendered PNG inspected visually</code>
- <code>Static verification: `.github/workflows/ci.yml` retains the raw `make paper-bench-check` regression step (ungated PAPER_BENCH) and adds the gate-test step; repo-wide grep shows 47.377 survives only in archived research/paper_data logs and the design doc</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
