### PR TITLE
fix(paper): verify the rounds ratchet on the configured TreeSA score instead of raw tc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,13 @@ cost). Restore the old behavior with `preprocess: false`.
   `waist_trace` benchmark set (five deterministic relabelings each of
   `surfacecode_d21` and `ksg`, 128 rounds each) regenerates the paper's dense
   mechanism evidence via `make paper-waist-trace`.
+- `RoundTrace` gains `score_before`/`score_retained`: the configured
+  multi-objective TreeSA score of the retained incumbent, which is the
+  quantity the rounds ratchet actually guarantees is monotone (`tc_retained`
+  can rise when another weighted term improves). Paper-benchmark artifacts
+  emit the fields when the manifest sets `trace_scores: true` (implied by
+  `trace_cuts`), and the `figure2b`/`waist_trace` verifiers now check the
+  configured-score ratchet instead of raw `tc`.
 - `Label` now requires `Ord` (all built-in label types already qualify).
 - The Julia behavioral-alignment rule is retired; JSON interop is unchanged.
 

--- a/benchmarks/paper/README.md
+++ b/benchmarks/paper/README.md
@@ -209,7 +209,10 @@ random circuit costs time and reports nothing anyone wants to read.
   trace from `RoundsReport::round_trace`: the retained incumbent before the
   round, the surgery candidate, the fine-tuning endpoint, and the retained
   incumbent afterward. `tc_after_anneal` may be worse after fine tuning, but
-  `tc_retained` cannot increase and is the tree used by the next round.
+  `score_retained` cannot exceed `score_before` and identifies the tree used by
+  the next round. `tc_retained` is the time complexity of that tree; it can
+  rise when the configured multi-objective score instead improves its space or
+  read-write term. Trace-enabled sets emit both score fields explicitly.
   `surgery_accepted` marks the rebuild events plotted as crosses in the paper's
   Figure 2(b).
 - When the manifest sets `trace_cuts: true`, each curve point also contains a

--- a/benchmarks/paper/README.md
+++ b/benchmarks/paper/README.md
@@ -7,7 +7,8 @@ reproducing that table means running it. The `figure2b` set separately
 reproduces the surface-code mechanism panel with a deterministic 32-round work
 budget: it must cross the panel's pre-surgery record and show an accepted
 rebuild causing a drop. It must also expose at least one uphill fine-tuning
-endpoint separately from the monotone retained incumbent. `waist_trace` is the
+endpoint separately from the retained incumbent, whose configured score is
+monotone even where its tensor cost is not. `waist_trace` is the
 dense mechanism set: five deterministic relabelings each
 of surfacecode_d21 and ksg, with 128 fixed-work rounds per relabeling and exact
 like-for-like waist/FM cut weights for every completed surgery call. The outputs under
@@ -55,7 +56,7 @@ This directory is self-contained — manifest, instances, checker:
 | `run_master.py` | Enforces current clean `origin/master`, builds the runner, and emits deterministic provenance. |
 | `test_run_master.py` | Unit tests for revision, cleanliness, tracking, hashing, and atomic-write behavior. |
 | `check.py` | Compares two artifacts and exits nonzero on any disagreement. Standard library only, Python 3.8+. |
-| `verify_figure2b.py` | Verifies the record crossing, incumbent ratchet, and accepted-rebuild mechanism. |
+| `verify_figure2b.py` | Verifies the record crossing, configured-score ratchet, and accepted-rebuild mechanism. |
 | `verify_waist_trace.py` | Verifies the `waist_trace` set: ten 128-round trajectories, per-round waist/FM cut invariants, and the rebuild gate/acceptance flags. |
 | `plot_figure2b.py` | Renders the checked JSON as a dependency-free vector figure. |
 | `README.md` | This file. |
@@ -212,7 +213,10 @@ random circuit costs time and reports nothing anyone wants to read.
   `score_retained` cannot exceed `score_before` and identifies the tree used by
   the next round. `tc_retained` is the time complexity of that tree; it can
   rise when the configured multi-objective score instead improves its space or
-  read-write term. Trace-enabled sets emit both score fields explicitly.
+  read-write term. When the manifest sets `trace_scores: true` (or
+  `trace_cuts: true`, which implies it), each curve point carries explicit
+  `score_before` and `score_retained` fields; the `figure2b` and `waist_trace`
+  sets enable this.
   `surgery_accepted` marks the rebuild events plotted as crosses in the paper's
   Figure 2(b).
 - When the manifest sets `trace_cuts: true`, each curve point also contains a
@@ -272,7 +276,9 @@ Allowed keys:
 - Arm `greedy`: none; `{}` is the only legal value.
 - Arm `treesa`: `ntrials`, `niters`.
 - Arm `treesa_rounds`: `ntrials`, `niters`, `rounds` (required), `trace_cuts`
-  (optional; emit the per-round `waist` object).
+  (optional; emit the per-round `waist` object and the score fields),
+  `trace_scores` (optional; emit the per-round `score_before`/`score_retained`
+  fields without the cut trace).
 - Arm `treesa_surgery_rule`: `ntrials`, `niters`, `probability` (required).
 - Instance: `name`, `path` (repo-root-relative), `treewidth` (required),
   `relabel_seed` (optional; deterministic tensor-order permutation applied

--- a/benchmarks/paper/expected/figure2b.json
+++ b/benchmarks/paper/expected/figure2b.json
@@ -19,257 +19,321 @@
         {
           "round": 0,
           "tc_before": 57.002219,
+          "score_before": 1.443380854600872e+17,
           "tc_after_surgery": 49.393878,
           "tc_after_anneal": 49.117768,
           "tc_retained": 49.115981,
+          "score_retained": 611175053378304.6,
           "surgery_accepted": true
         },
         {
           "round": 1,
           "tc_before": 49.115981,
+          "score_before": 611175053378304.6,
           "tc_after_surgery": 49.115981,
           "tc_after_anneal": 49.122226,
           "tc_retained": 49.096415,
+          "score_retained": 602956869463028.4,
           "surgery_accepted": false
         },
         {
           "round": 2,
           "tc_before": 49.096415,
+          "score_before": 602956869463028.4,
           "tc_after_surgery": 49.096415,
           "tc_after_anneal": 49.098734,
           "tc_retained": 49.09346,
+          "score_retained": 601725516453120.9,
           "surgery_accepted": false
         },
         {
           "round": 3,
           "tc_before": 49.09346,
+          "score_before": 601725516453120.9,
           "tc_after_surgery": 49.09346,
           "tc_after_anneal": 49.093456,
           "tc_retained": 49.087159,
+          "score_retained": 599107798705474.0,
           "surgery_accepted": false
         },
         {
           "round": 4,
           "tc_before": 49.087159,
+          "score_before": 599107798705474.0,
           "tc_after_surgery": 49.087159,
           "tc_after_anneal": 49.11702,
           "tc_retained": 49.087159,
+          "score_retained": 599107798705474.0,
           "surgery_accepted": false
         },
         {
           "round": 5,
           "tc_before": 49.087159,
+          "score_before": 599107798705474.0,
           "tc_after_surgery": 49.087159,
           "tc_after_anneal": 49.099231,
           "tc_retained": 49.080445,
+          "score_retained": 596331335110093.8,
           "surgery_accepted": false
         },
         {
           "round": 6,
           "tc_before": 49.080445,
+          "score_before": 596331335110093.8,
           "tc_after_surgery": 49.080445,
           "tc_after_anneal": 49.090911,
           "tc_retained": 49.070349,
+          "score_retained": 592180603403389.6,
           "surgery_accepted": false
         },
         {
           "round": 7,
           "tc_before": 49.070349,
+          "score_before": 592180603403389.6,
           "tc_after_surgery": 49.070349,
           "tc_after_anneal": 49.076697,
           "tc_retained": 49.062165,
+          "score_retained": 588837063328277.6,
           "surgery_accepted": false
         },
         {
           "round": 8,
           "tc_before": 49.062165,
+          "score_before": 588837063328277.6,
           "tc_after_surgery": 49.062165,
           "tc_after_anneal": 49.056196,
           "tc_retained": 49.048423,
+          "score_retained": 583265107200630.1,
           "surgery_accepted": false
         },
         {
           "round": 9,
           "tc_before": 49.048423,
+          "score_before": 583265107200630.1,
           "tc_after_surgery": 49.048423,
           "tc_after_anneal": 49.098136,
           "tc_retained": 49.048423,
+          "score_retained": 583265107200630.1,
           "surgery_accepted": false
         },
         {
           "round": 10,
           "tc_before": 49.048423,
+          "score_before": 583265107200630.1,
           "tc_after_surgery": 49.048423,
           "tc_after_anneal": 49.045089,
           "tc_retained": 49.044025,
+          "score_retained": 581493142159238.6,
           "surgery_accepted": false
         },
         {
           "round": 11,
           "tc_before": 49.044025,
+          "score_before": 581493142159238.6,
           "tc_after_surgery": 48.531859,
           "tc_after_anneal": 48.237733,
           "tc_retained": 48.232769,
+          "score_retained": 331857319164101.8,
           "surgery_accepted": true
         },
         {
           "round": 12,
           "tc_before": 48.232769,
+          "score_before": 331857319164101.8,
           "tc_after_surgery": 48.232769,
           "tc_after_anneal": 48.18526,
           "tc_retained": 48.18526,
+          "score_retained": 321142823234936.7,
           "surgery_accepted": false
         },
         {
           "round": 13,
           "tc_before": 48.18526,
+          "score_before": 321142823234936.7,
           "tc_after_surgery": 48.18526,
           "tc_after_anneal": 48.178409,
           "tc_retained": 48.178409,
+          "score_retained": 319626561420996.1,
           "surgery_accepted": false
         },
         {
           "round": 14,
           "tc_before": 48.178409,
+          "score_before": 319626561420996.1,
           "tc_after_surgery": 48.178409,
           "tc_after_anneal": 48.166533,
           "tc_retained": 48.164728,
+          "score_retained": 316620127437618.06,
           "surgery_accepted": false
         },
         {
           "round": 15,
           "tc_before": 48.164728,
+          "score_before": 316620127437618.06,
           "tc_after_surgery": 47.987115,
           "tc_after_anneal": 47.973818,
           "tc_retained": 47.973514,
+          "score_retained": 277454104561461.1,
           "surgery_accepted": true
         },
         {
           "round": 16,
           "tc_before": 47.973514,
+          "score_before": 277454104561461.1,
           "tc_after_surgery": 47.973514,
           "tc_after_anneal": 47.967169,
           "tc_retained": 47.955052,
+          "score_retained": 273940138092165.03,
           "surgery_accepted": false
         },
         {
           "round": 17,
           "tc_before": 47.955052,
+          "score_before": 273940138092165.03,
           "tc_after_surgery": 47.955052,
           "tc_after_anneal": 47.939061,
           "tc_retained": 47.939061,
+          "score_retained": 270932742469570.9,
           "surgery_accepted": false
         },
         {
           "round": 18,
           "tc_before": 47.939061,
+          "score_before": 270932742469570.9,
           "tc_after_surgery": 47.939061,
           "tc_after_anneal": 47.902686,
           "tc_retained": 47.902686,
+          "score_retained": 264214435024995.47,
           "surgery_accepted": false
         },
         {
           "round": 19,
           "tc_before": 47.902686,
+          "score_before": 264214435024995.47,
           "tc_after_surgery": 47.902686,
           "tc_after_anneal": 47.916815,
           "tc_retained": 47.885666,
+          "score_retained": 261128509389491.66,
           "surgery_accepted": false
         },
         {
           "round": 20,
           "tc_before": 47.885666,
+          "score_before": 261128509389491.66,
           "tc_after_surgery": 47.885666,
           "tc_after_anneal": 47.888411,
           "tc_retained": 47.883194,
+          "score_retained": 260683337867605.03,
           "surgery_accepted": false
         },
         {
           "round": 21,
           "tc_before": 47.883194,
+          "score_before": 260683337867605.03,
           "tc_after_surgery": 47.883194,
           "tc_after_anneal": 47.856423,
           "tc_retained": 47.856423,
+          "score_retained": 255910828701826.88,
           "surgery_accepted": false
         },
         {
           "round": 22,
           "tc_before": 47.856423,
+          "score_before": 255910828701826.88,
           "tc_after_surgery": 47.856423,
           "tc_after_anneal": 47.94255,
           "tc_retained": 47.852219,
+          "score_retained": 255169489769988.6,
           "surgery_accepted": false
         },
         {
           "round": 23,
           "tc_before": 47.852219,
+          "score_before": 255169489769988.6,
           "tc_after_surgery": 47.852219,
           "tc_after_anneal": 47.838297,
           "tc_retained": 47.836656,
+          "score_retained": 252443387411952.97,
           "surgery_accepted": false
         },
         {
           "round": 24,
           "tc_before": 47.836656,
+          "score_before": 252443387411952.97,
           "tc_after_surgery": 47.836656,
           "tc_after_anneal": 47.82522,
           "tc_retained": 47.82522,
+          "score_retained": 250458885634615.62,
           "surgery_accepted": false
         },
         {
           "round": 25,
           "tc_before": 47.82522,
+          "score_before": 250458885634615.62,
           "tc_after_surgery": 47.82522,
           "tc_after_anneal": 47.825205,
           "tc_retained": 47.825205,
+          "score_retained": 250456396914675.03,
           "surgery_accepted": false
         },
         {
           "round": 26,
           "tc_before": 47.825205,
+          "score_before": 250456396914675.03,
           "tc_after_surgery": 47.825205,
           "tc_after_anneal": 47.799579,
           "tc_retained": 47.799528,
+          "score_retained": 246057569175124.72,
           "surgery_accepted": false
         },
         {
           "round": 27,
           "tc_before": 47.799528,
+          "score_before": 246057569175124.72,
           "tc_after_surgery": 47.799528,
           "tc_after_anneal": 47.72405,
           "tc_retained": 47.72174,
+          "score_retained": 233199477860610.28,
           "surgery_accepted": false
         },
         {
           "round": 28,
           "tc_before": 47.72174,
+          "score_before": 233199477860610.28,
           "tc_after_surgery": 47.72174,
           "tc_after_anneal": 47.798929,
           "tc_retained": 47.72174,
+          "score_retained": 233199477860610.28,
           "surgery_accepted": false
         },
         {
           "round": 29,
           "tc_before": 47.72174,
+          "score_before": 233199477860610.28,
           "tc_after_surgery": 47.72174,
           "tc_after_anneal": 47.797369,
           "tc_retained": 47.72174,
+          "score_retained": 233199477860610.28,
           "surgery_accepted": false
         },
         {
           "round": 30,
           "tc_before": 47.72174,
+          "score_before": 233199477860610.28,
           "tc_after_surgery": 47.72174,
           "tc_after_anneal": 47.778427,
           "tc_retained": 47.72174,
+          "score_retained": 233199477860610.28,
           "surgery_accepted": false
         },
         {
           "round": 31,
           "tc_before": 47.72174,
+          "score_before": 233199477860610.28,
           "tc_after_surgery": 47.72174,
           "tc_after_anneal": 47.721453,
           "tc_retained": 47.678726,
+          "score_retained": 226381638414901.56,
           "surgery_accepted": false
         }
       ]

--- a/benchmarks/paper/manifest.json
+++ b/benchmarks/paper/manifest.json
@@ -17,7 +17,7 @@
     "figure2b": {
       "arms": {
         "treesa": {},
-        "treesa_rounds": {"rounds": 32}
+        "treesa_rounds": {"rounds": 32, "trace_scores": true}
       },
       "instances": [
         {"name": "surfacecode_d21", "path": "benchmarks/paper/instances/surfacecode_d21.json", "treewidth": false}
@@ -25,7 +25,7 @@
     },
     "waist_trace": {
       "arms": {
-        "treesa_rounds": {"rounds": 128, "trace_cuts": true}
+        "treesa_rounds": {"rounds": 128, "trace_cuts": true, "trace_scores": true}
       },
       "instances": [
         {"name": "surfacecode_d21_r0", "path": "benchmarks/paper/instances/surfacecode_d21.json", "treewidth": false, "relabel_seed": 5400},

--- a/benchmarks/paper/verify_figure2b.py
+++ b/benchmarks/paper/verify_figure2b.py
@@ -2,6 +2,7 @@
 """Verify the semantic contract behind the Figure 2(b) reproduction set."""
 
 import json
+import math
 import sys
 from pathlib import Path
 
@@ -40,8 +41,13 @@ def main() -> None:
     worse_endpoints = 0
     previous = None
     for point in curve:
-        if point["tc_retained"] > point["tc_before"]:
-            fail(f"retained incumbent rises in round {point['round']}")
+        score_before = point.get("score_before")
+        score_retained = point.get("score_retained")
+        if not all(isinstance(value, (int, float)) and math.isfinite(value)
+                   for value in (score_before, score_retained)):
+            fail(f"round {point['round']}: missing configured score")
+        if score_retained > score_before:
+            fail(f"configured-score ratchet rises in round {point['round']}")
         if previous is not None and point["tc_before"] != previous:
             fail(f"round {point['round']} does not continue from the retained incumbent")
         if point["surgery_accepted"] and point["tc_after_surgery"] < point["tc_before"]:

--- a/benchmarks/paper/verify_waist_trace.py
+++ b/benchmarks/paper/verify_waist_trace.py
@@ -65,8 +65,13 @@ def main() -> None:
                 fail(f"{name} round {expected_round}: rebuild gate mismatch")
             if waist.get("rebuild_accepted") is not point.get("surgery_accepted"):
                 fail(f"{name} round {expected_round}: acceptance mismatch")
-            if point["tc_retained"] > point["tc_before"] + 1e-9:
-                fail(f"{name} round {expected_round}: incumbent ratchet rose")
+            score_before = point.get("score_before")
+            score_retained = point.get("score_retained")
+            if not all(isinstance(value, (int, float)) and math.isfinite(value)
+                       for value in (score_before, score_retained)):
+                fail(f"{name} round {expected_round}: missing configured score")
+            if score_retained > score_before:
+                fail(f"{name} round {expected_round}: configured-score ratchet rose")
             comparisons.append((family, incumbent, candidate))
 
     if families != {"surfacecode_d21": 5, "ksg": 5}:

--- a/docs/src/algorithms/default-pipeline.md
+++ b/docs/src/algorithms/default-pipeline.md
@@ -40,8 +40,11 @@ simplify  ->  anneal trials  ->  [k x (surgery -> cold fine tune)]  ->  splice
 
    Rounds use an *incumbent ratchet*: a worse fine-tuning endpoint is reported
    but rejected, and round `r + 1` starts from the best tree retained in round
-   `r`. Surgery supplies the nonlocal basin jump; fine tuning need not destroy
-   the incumbent to provide one.
+   `r`. "Best" means best under the configured multi-objective `TreeSA` score,
+   so the retained tree's raw time complexity can rise when another weighted
+   term improves — see the [`treesa::anneal_surgery_rounds`] docs for the exact
+   ratchet contract. Surgery supplies the nonlocal basin jump; fine tuning need
+   not destroy the incumbent to provide one.
 
    **Cost:** on the 761-tensor simplified surface-code network, fine tuning is
    450 sweeps per round, versus 15,000 sweeps for a default cold-start trial.
@@ -80,8 +83,8 @@ deadline binds `optimize_treesa`). Re-running the same configuration
 reproduces the same tree on any machine, with `surgery_iters` at any value:
 `0` (off), or any positive round count. Every positive-round result is guarded
 against the rounds-off baseline after splice-back. The standalone
-`anneal_surgery_rounds` loop is monotone in its round count on the network it
-is given.
+`anneal_surgery_rounds` loop is monotone in its round count, under the
+configured `TreeSA` score, on the network it is given.
 
 Wall-clock budgets still exist, but only on the low-level
 [`crate::waist_surgery::refine`] / [`refine_capped`] APIs (and the Python
@@ -179,3 +182,4 @@ ignored rather than allowed to return a non-path tree.
 [`crate::waist_surgery::refine_capped`]: https://docs.rs/omeco/latest/omeco/waist_surgery/fn.refine_capped.html
 [`refine_capped`]: https://docs.rs/omeco/latest/omeco/waist_surgery/fn.refine_capped.html
 [`TreeSA::surgery_iters`]: https://docs.rs/omeco/latest/omeco/treesa/struct.TreeSA.html#structfield.surgery_iters
+[`treesa::anneal_surgery_rounds`]: https://docs.rs/omeco/latest/omeco/treesa/fn.anneal_surgery_rounds.html

--- a/omeco/examples/paper_bench.rs
+++ b/omeco/examples/paper_bench.rs
@@ -97,6 +97,21 @@ struct RoundsArm {
     rounds: u64,
     /// Emit exact per-round waist-cut comparisons for mechanism figures.
     trace_cuts: Option<bool>,
+    /// Emit per-round configured-score fields without the full cut trace.
+    trace_scores: Option<bool>,
+}
+
+impl RoundsArm {
+    /// The `waist` object is emitted only for `trace_cuts` sets.
+    fn emit_cuts(&self) -> bool {
+        self.trace_cuts.unwrap_or(false)
+    }
+
+    /// `score_before`/`score_retained` accompany either trace flag: a cut
+    /// trace without the score ratchet would be unverifiable.
+    fn emit_scores(&self) -> bool {
+        self.emit_cuts() || self.trace_scores.unwrap_or(false)
+    }
 }
 
 #[derive(Debug, Deserialize)]
@@ -388,21 +403,14 @@ fn run_instance(
             .map(|trace| CurvePoint {
                 round: trace.round,
                 tc_before: round6(trace.tc_before),
-                score_before: arm
-                    .trace_cuts
-                    .unwrap_or(false)
-                    .then_some(round6(trace.score_before)),
+                score_before: arm.emit_scores().then_some(round6(trace.score_before)),
                 tc_after_surgery: round6(trace.tc_after_surgery),
                 tc_after_anneal: round6(trace.tc_after_anneal),
                 tc_retained: round6(trace.tc_retained),
-                score_retained: arm
-                    .trace_cuts
-                    .unwrap_or(false)
-                    .then_some(round6(trace.score_retained)),
+                score_retained: arm.emit_scores().then_some(round6(trace.score_retained)),
                 surgery_accepted: trace.surgery_accepted,
                 waist: arm
-                    .trace_cuts
-                    .unwrap_or(false)
+                    .emit_cuts()
                     .then_some(trace.waist)
                     .flatten()
                     .map(|waist| WaistPoint {
@@ -521,7 +529,7 @@ fn main() {
 
 #[cfg(test)]
 mod tests {
-    use super::{permute_tensors, CurvePoint};
+    use super::{permute_tensors, CurvePoint, RoundsArm};
 
     #[test]
     fn tensor_relabeling_is_seeded_and_deterministic() {
@@ -537,6 +545,24 @@ mod tests {
         assert_ne!(first, other);
         first.sort();
         assert_eq!(first, original);
+    }
+
+    #[test]
+    fn score_fields_follow_either_trace_flag() {
+        let arm = |trace_cuts, trace_scores| RoundsArm {
+            ntrials: None,
+            niters: None,
+            rounds: 1,
+            trace_cuts,
+            trace_scores,
+        };
+
+        assert!(!arm(None, None).emit_scores());
+        assert!(arm(Some(true), None).emit_scores());
+        assert!(arm(None, Some(true)).emit_scores());
+        assert!(!arm(Some(false), Some(false)).emit_scores());
+        assert!(arm(Some(true), None).emit_cuts());
+        assert!(!arm(None, Some(true)).emit_cuts());
     }
 
     #[test]

--- a/omeco/examples/paper_bench.rs
+++ b/omeco/examples/paper_bench.rs
@@ -162,9 +162,13 @@ struct ResultRow {
 struct CurvePoint {
     round: u64,
     tc_before: f64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    score_before: Option<f64>,
     tc_after_surgery: f64,
     tc_after_anneal: f64,
     tc_retained: f64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    score_retained: Option<f64>,
     surgery_accepted: bool,
     /// Exact like-for-like cut comparison, emitted only when requested by the
     /// manifest's `trace_cuts` flag.
@@ -384,9 +388,17 @@ fn run_instance(
             .map(|trace| CurvePoint {
                 round: trace.round,
                 tc_before: round6(trace.tc_before),
+                score_before: arm
+                    .trace_cuts
+                    .unwrap_or(false)
+                    .then_some(round6(trace.score_before)),
                 tc_after_surgery: round6(trace.tc_after_surgery),
                 tc_after_anneal: round6(trace.tc_after_anneal),
                 tc_retained: round6(trace.tc_retained),
+                score_retained: arm
+                    .trace_cuts
+                    .unwrap_or(false)
+                    .then_some(round6(trace.score_retained)),
                 surgery_accepted: trace.surgery_accepted,
                 waist: arm
                     .trace_cuts
@@ -509,7 +521,7 @@ fn main() {
 
 #[cfg(test)]
 mod tests {
-    use super::permute_tensors;
+    use super::{permute_tensors, CurvePoint};
 
     #[test]
     fn tensor_relabeling_is_seeded_and_deterministic() {
@@ -525,5 +537,28 @@ mod tests {
         assert_ne!(first, other);
         first.sort();
         assert_eq!(first, original);
+    }
+
+    #[test]
+    fn trace_scores_are_opt_in_artifact_fields() {
+        let point = |score_before, score_retained| CurvePoint {
+            round: 0,
+            tc_before: 1.0,
+            score_before,
+            tc_after_surgery: 1.0,
+            tc_after_anneal: 1.0,
+            tc_retained: 1.0,
+            score_retained,
+            surgery_accepted: false,
+            waist: None,
+        };
+
+        let ordinary = serde_json::to_value(point(None, None)).unwrap();
+        assert!(ordinary.get("score_before").is_none());
+        assert!(ordinary.get("score_retained").is_none());
+
+        let traced = serde_json::to_value(point(Some(2.0), Some(1.5))).unwrap();
+        assert_eq!(traced["score_before"], 2.0);
+        assert_eq!(traced["score_retained"], 1.5);
     }
 }

--- a/omeco/src/treesa.rs
+++ b/omeco/src/treesa.rs
@@ -57,10 +57,11 @@ pub struct TreeSA {
     /// The best reduced-network tree seen in the loop is returned. After
     /// splice-back, [`optimize_treesa`] compares it with the rounds-off result
     /// on the original network, so enabling any positive round count is never
-    /// worse than leaving the loop off. The standalone
+    /// worse than leaving the loop off under the configured [`TreeSA::score`]
+    /// (`tc` alone carries no such guarantee). The standalone
     /// [`anneal_surgery_rounds`] loop is additionally monotone in its round
-    /// count on the network it is given. See [`crate::waist_surgery`] for the
-    /// surgery step itself.
+    /// count, under that same score, on the network it is given. See
+    /// [`crate::waist_surgery`] for the surgery step itself.
     ///
     /// # Path decomposition
     ///
@@ -989,8 +990,8 @@ fn get_child_labels<L: Label>(nested: &NestedEinsum<L>, original_ixs: &[Vec<L>])
 /// search and side rebuilds operate on the simplified tensor hypergraph, not on
 /// the restored full graph. After splice-back, the candidate is compared with
 /// the rounds-off tree on the original network, so the result is never worse
-/// than with `surgery_iters = 0`. The whole pipeline is fully deterministic
-/// (rounds are counted, never timed).
+/// than with `surgery_iters = 0` under the configured [`TreeSA::score`]. The
+/// whole pipeline is fully deterministic (rounds are counted, never timed).
 ///
 /// [`TreeSA::preprocess`] is automatically treated as disabled whenever
 /// [`TreeSA::decomposition_type`] is [`DecompositionType::Path`], even if the

--- a/omeco/src/treesa.rs
+++ b/omeco/src/treesa.rs
@@ -1371,14 +1371,21 @@ pub struct RoundTrace {
     pub round: u64,
     /// Retained incumbent before surgery.
     pub tc_before: f64,
+    /// Configured TreeSA score of the retained incumbent before surgery.
+    pub score_before: f64,
     /// Candidate after the surgery step (equal to `tc_before` if rejected).
     pub tc_after_surgery: f64,
     /// Raw endpoint of the cold fine-tuning pass, whether retained or rejected.
     /// The field keeps its historical `anneal` name for artifact compatibility.
     pub tc_after_anneal: f64,
     /// Best of the round incumbent, surgery candidate, and all sweep
-    /// checkpoints observed during fine tuning.
+    /// checkpoints observed during fine tuning, reported in time-complexity
+    /// units. This can rise when the configured multi-objective score improves
+    /// by reducing its space or read-write term.
     pub tc_retained: f64,
+    /// Configured TreeSA score of the incumbent retained for the next round.
+    /// Unlike `tc_retained`, this is guaranteed not to exceed `score_before`.
+    pub score_retained: f64,
     /// Whether waist surgery accepted a rebuilt tree in this round.
     pub surgery_accepted: bool,
     /// Exact cut-space comparison made by this round's surgery call.
@@ -1399,18 +1406,22 @@ pub struct RoundTrace {
 ///
 /// Even cold fine tuning may finish at a worse tree. That endpoint is recorded in
 /// [`RoundsReport::round_scores`] and [`RoundsReport::round_trace`], but it does
-/// not replace the incumbent. Round `r + 1` starts from the best of round `r`'s
-/// input, surgery result, and best sweep checkpoint observed during fine tuning. This
-/// matches the paper's `Anneal(T, C_outer)` contract: annealing returns its
-/// best retained tree.
+/// not replace the incumbent unless it improves [`TreeSA::score`]. Round `r + 1`
+/// starts from the best configured-score candidate among round `r`'s input,
+/// surgery result, and best sweep checkpoint observed during fine tuning. This
+/// matches the paper's `Anneal(T, C_outer)` contract: annealing returns its best
+/// retained tree. With a multi-objective score, the retained tree's `tc` can
+/// rise when another weighted term improves; [`RoundTrace::score_retained`] is
+/// the monotone ratchet diagnostic.
 ///
 /// # Never worse, monotone in `rounds`
 ///
-/// The *returned* tree is the best tree seen anywhere in the run, including the
-/// `seed` itself and each round's post-surgery, pre-fine-tuning tree. Consequently
-/// the result is never worse than `seed`, and — because rounds are chained
-/// deterministically — running `n + 1` rounds is always equal or better than
-/// running `n`.
+/// The *returned* tree is the best configured-score tree seen anywhere in the
+/// run, including the `seed` itself and each round's post-surgery,
+/// pre-fine-tuning tree. Consequently the result is never worse than `seed`
+/// under [`TreeSA::score`], and — because rounds are chained deterministically —
+/// running `n + 1` rounds is always equal or better than running `n` under that
+/// same score.
 ///
 /// # Configuration used
 ///
@@ -1573,9 +1584,11 @@ pub fn anneal_surgery_rounds<L: Label>(
         report.round_trace.push(RoundTrace {
             round: r,
             tc_before,
+            score_before: incumbent_score,
             tc_after_surgery,
             tc_after_anneal,
             tc_retained: crate::contraction_complexity(&retained, size_dict, &code.ixs).tc,
+            score_retained: retained_score,
             surgery_accepted: wr.rebuild_accepts > 0,
             waist: waist_trace,
         });
@@ -3389,7 +3402,7 @@ mod tests {
         assert!(r1.round_trace.iter().all(|trace| trace.waist.is_some()));
         for pair in r1.round_trace.windows(2) {
             assert_eq!(pair[1].tc_before, pair[0].tc_retained);
-            assert!(pair[1].tc_retained <= pair[1].tc_before + 1e-9);
+            assert!(pair[1].score_retained <= pair[1].score_before);
         }
     }
 


### PR DESCRIPTION
## Intent

Repair the paper evidence pipeline so Figure 2(a) is a meaningful, reproducible current-master mechanism test rather than the odd accepted-drop plot. Preserve TreeSA's intended multi-objective retention semantics: do not change the algorithm merely to force tensor cost to be monotone. Trace and verify the configured score ratchet explicitly, keep ordinary benchmark artifacts unchanged unless trace_cuts is enabled, retain the historical 1,226-call evidence, and use a new 1,280-call current-master Huawei trace for the revised waist-cut-versus-FM-cut scatter. The paper version must always track exact OMECO master as a hard gate.

## What Changed

- `RoundTrace` now records `score_before`/`score_retained` — the configured multi-objective TreeSA score of the retained incumbent — and the rustdoc for `anneal_surgery_rounds`/the rounds loop is qualified to state that the never-worse/monotone guarantee holds under that configured score, not raw `tc` (which can rise when a weighted space or read-write term improves).
- `paper_bench` gains an opt-in `trace_scores` manifest flag (implied by `trace_cuts`) that emits the score fields per curve point; ordinary benchmark artifacts are byte-unchanged when neither flag is set, with unit tests covering the flag semantics and opt-in serialization.
- `verify_figure2b.py` and `verify_waist_trace.py` now enforce the ratchet on the configured score (and require the fields to be present and finite) instead of the false tc-monotonicity invariant; the manifest enables `trace_scores` for the `figure2b` and `waist_trace` sets, and `expected/figure2b.json` was regenerated with the score fields (`make paper-figure2b-check` and `make paper-bench-check` both pass, per the pipeline's Test phase).

## Risk Assessment

✅ Low: Both prior findings are resolved exactly as the author directed: the regenerated figure2b expected artifact adds only the two configured-score fields per round (64 insertions, 0 deletions), independently satisfies every verifier invariant including the score ratchet and cross-round chain, matches the default score formula to ~1e-7 relative, and the branch as a whole meets all in-scope intent criteria with the algorithm untouched and ordinary artifacts unchanged.

## Testing

Exercised the score-ratchet tracing change at every layer: targeted Rust unit tests for the new trace flags and RoundTrace fields, the semantic verifier on the regenerated figure2b artifact plus two negative controls proving it rejects ratchet violations and missing scores, a full fresh figure2b reproduction that exactly matches the committed expected artifact and its rendered SVG, a fresh ordinary ci-set run matching the pre-change committed artifact (proving no-trace-flag artifacts are unchanged), a three-way flag demo showing score fields are opt-in and tracing never perturbs the optimization, and the master-gate unit tests. The 1,280-call waist_trace artifact itself was not regenerated because its make target is deliberately gated on a clean origin/master checkout (this is a branch), but its verifier change is structurally identical to the figure2b one validated with negative controls. All checks passed with a clean worktree.

<details>
<summary>Evidence: Figure 2(b) end-to-end reproduction transcript</summary>

`make paper-figure2b-check: paper_bench wrote fresh artifact (2 results, 105.8s); verify_figure2b: OK: tc=47.678726 < 47.824; accepted rebuild drops=3; uphill endpoints=13; rounds=32; check.py: OK: 2 results compared; rendered SVG identical to committed expected/figure2b.svg`

```text
$ make paper-figure2b-check   # fresh figure2b run -> semantic verifier -> compare vs committed expected
  surfacecode_d21      treesa         ...
  surfacecode_d21      treesa_rounds  ...
paper_bench: wrote $TMPDIR/tmp.kHM4cd0bdo (2 results, 105.8s)
OK: tc=47.678726 < 47.824; accepted rebuild drops=3; uphill endpoints=13; rounds=32
OK: 2 results compared

$ python3 benchmarks/paper/plot_figure2b.py benchmarks/paper/expected/figure2b.json figure2b_rendered.svg
$ diff -q figure2b_rendered.svg benchmarks/paper/expected/figure2b.svg
committed SVG matches fresh render
```
</details>
- Evidence: Rendered Figure 2(b) SVG (fresh render, byte-identical to committed) (local file: <code>/var/folders/nn/smw2hcnx18z1l6blf_p59x740000gn/T/no-mistakes-evidence/01KZ4RWPQW9ZP8GP05PVTPX303/figure2b_rendered.svg</code>)
<details>
<summary>Evidence: Verifier pass + negative controls (ratchet violation and missing score both rejected)</summary>

`verify_figure2b.py on expected artifact: OK. Tampered score_retained: 'FAIL: configured-score ratchet rises in round 5' (exit 1). Deleted score field: 'FAIL: round 7: missing configured score' (exit 1).`

```text
$ python3 benchmarks/paper/verify_figure2b.py benchmarks/paper/expected/figure2b.json
OK: tc=47.678726 < 47.824; accepted rebuild drops=3; uphill endpoints=13; rounds=32

Negative control 1 - score_retained tampered above score_before in round 5:
$ python3 benchmarks/paper/verify_figure2b.py bad_ratchet.json
verify_figure2b.py: FAIL: configured-score ratchet rises in round 5   (exit 1)

Negative control 2 - score_retained field deleted from round 7:
$ python3 benchmarks/paper/verify_figure2b.py bad_missing.json
verify_figure2b.py: FAIL: round 7: missing configured score           (exit 1)

Regenerated expected artifact properties (benchmarks/paper/expected/figure2b.json):
  rounds with tc_retained > tc_before: []  (tc happens to be monotone here)
  score ratchet monotone: True
  score chain continuous across rounds (score_before[r+1] == score_retained[r]): True
```
</details>
<details>
<summary>Evidence: Ordinary artifacts unchanged: fresh ci set vs pre-change committed expected</summary>

`make paper-bench-check: fresh ci-set artifact (44.5s) compared against committed expected/ci.json (not regenerated by this change): OK: 17 results compared`

```text
$ make paper-bench-check   # fresh ci-set run (no trace flags) vs committed pre-change expected/ci.json
  dbn_13               greedy         0.0s
  dbn_13               treesa         2.5s
  dbn_13               treesa_rounds  8.3s
  dbn_13               treewidth      0.0s
  qft_27               greedy         0.1s
  qft_27               treesa         8.2s
  qft_27               treesa_rounds  9.1s
  surfacecode_d9       greedy         0.0s
  surfacecode_d9       treesa         1.4s
  surfacecode_d9       treesa_rounds  1.6s
  reg3_250             greedy         0.0s
  reg3_250             treesa         5.8s
  reg3_250             treesa_rounds  7.5s
paper_bench: wrote $TMPDIR/tmp.jBWUm7qhNC (17 results, 44.5s)
OK: 17 results compared

expected/ci.json was NOT regenerated by this change; agreement proves ordinary
(no-trace-flag) benchmark artifacts are unchanged.
```
</details>
<details>
<summary>Evidence: Trace-flag semantics demo (plain vs trace_scores vs trace_cuts artifacts)</summary>

`PASS: ordinary artifact has no score_before/score_retained/waist fields; PASS: trace_scores emits monotone, round-chained score fields without waist; PASS: trace_cuts implies score fields; PASS: tc trajectory identical across all three flag settings (tracing is observation-only). Raw artifacts saved as demo_plain.json / demo_scores.json / demo_cuts.json.`

```text
paper_bench trace-flag semantics demo (petersen, 4 rounds, ntrials=4)
  PASS: ordinary artifact (no trace flags): NO score_before/score_retained/waist fields  -- unchanged shape
  PASS: trace_scores artifact: score fields present, ratchet monotone, chained across rounds, no waist object
  PASS: trace_cuts artifact: waist object AND score fields present (trace_cuts implies trace_scores)
  PASS: tc trajectory identical across all three flag settings -- tracing is observation-only

Sample trace_scores curve point:
{
  "round": 0,
  "tc_before": 8.491853,
  "score_before": 360.0,
  "tc_after_surgery": 8.491853,
  "tc_after_anneal": 8.491853,
  "tc_retained": 8.491853,
  "score_retained": 360.0,
  "surgery_accepted": false
}

Sample ordinary curve point:
{
  "round": 0,
  "tc_before": 8.491853,
  "tc_after_surgery": 8.491853,
  "tc_after_anneal": 8.491853,
  "tc_retained": 8.491853,
  "surgery_accepted": false
}
```
</details>
<details>
<summary>Evidence: Targeted Rust unit test results</summary>

`paper_bench example tests: 3 passed (score_fields_follow_either_trace_flag, trace_scores_are_opt_in_artifact_fields, tensor_relabeling_is_seeded_and_deterministic); treesa::tests::test_rounds_report_shape_and_determinism: 1 passed`

```text
$ cargo test --release -p omeco --example paper_bench
test tests::score_fields_follow_either_trace_flag ... ok
test tests::tensor_relabeling_is_seeded_and_deterministic ... ok
test tests::trace_scores_are_opt_in_artifact_fields ... ok
test result: ok. 3 passed; 0 failed

$ cargo test --release -p omeco --lib test_rounds_report_shape_and_determinism
test treesa::tests::test_rounds_report_shape_and_determinism ... ok
test result: ok. 1 passed; 0 failed; 538 filtered out
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed (2) ✅</summary>

- ⚠️ `benchmarks/paper/verify_figure2b.py:43` - verify_figure2b.py line 43 still enforces the false tc-monotonicity invariant (`tc_retained &gt; tc_before` → hard fail, zero tolerance) that this commit removes from verify_waist_trace.py. The figure2b set runs the same treesa_rounds arm on surfacecode_d21, whose committed artifact has sc = 40.0 &gt; default sc_target = 20.0, so the configured score&#39;s space-penalty term is active and a round can legitimately retain a tree with higher tc when sc improves — the exact mechanism that motivated this fix. The committed figure2b artifact passes today, but the intent&#39;s hard gate requires regenerating it whenever OMECO master moves, so `make paper-figure2b-check` can spuriously fail with &#39;retained incumbent rises&#39; on a correct run. Recommend verifying the ratchet at the same boundary this commit established — the configured score — either by emitting score_before/score_retained for the figure2b set (schema + expected-artifact regeneration) or by relaxing/removing the tc-based assertion; the choice affects what the figure2b gate certifies, so it needs the author&#39;s call.

🔧 Fix: figure2b regeneration still running; verification pending
1 error still open:
- 🚨 `benchmarks/paper/expected/figure2b.json:1` - The committed benchmarks/paper/expected/figure2b.json was not regenerated after the manifest enabled trace_scores for the figure2b set (manifest.json line 20): its curve points still contain only the six tc fields with no score_before/score_retained. This makes the repo&#39;s own gate fail deterministically: `make paper-figure2b-check` produces a fresh artifact carrying the score fields and check.py dies on the nested key-set mismatch against the stale expected file (compare() recurses into curve points and fails on dict key differences), and verify_figure2b.py run against the committed artifact fails with &#39;missing configured score&#39; (line 48). The HEAD commit message (&#39;figure2b regeneration still running; verification pending&#39;) confirms the regeneration is in flight on the author&#39;s machine. The change must not merge until the regenerated expected/figure2b.json is committed. Flagged ask-user rather than auto-fix so the pipeline does not launch a duplicate long benchmark run that races the author&#39;s in-flight regeneration; the author should land the regenerated artifact (and confirm verify_figure2b.py + check.py pass against it) in the next round.

🔧 Fix: regenerate figure2b expected artifact with configured-score fields
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`python3 benchmarks/paper/verify_figure2b.py benchmarks/paper/expected/figure2b.json` (passes: record crossing, 3 accepted rebuilds, 13 uphill endpoints, 32 rounds)</code>
- <code>Negative controls: tampered `score_retained` above `score_before` and deleted `score_retained` field both correctly rejected by `verify_figure2b.py` with exit 1</code>
- <code>`make paper-figure2b-check` — fresh figure2b run (105.8s) → semantic verifier → `check.py` exact agreement with regenerated `expected/figure2b.json`</code>
- <code>`make paper-bench-check` — fresh ordinary ci-set run (no trace flags) agrees with committed pre-change `expected/ci.json` (17 results compared, OK)</code>
- <code>End-to-end flag-semantics demo with the real `paper_bench` binary on petersen: ordinary artifact has no score/waist fields; `trace_scores` emits monotone, round-chained score fields without cuts; `trace_cuts` implies scores; tc trajectory identical across all three settings</code>
- <code>`cargo test --release -p omeco --example paper_bench` (3 tests incl. new `score_fields_follow_either_trace_flag`, `trace_scores_are_opt_in_artifact_fields`)</code>
- <code>`cargo test --release -p omeco --lib test_rounds_report_shape_and_determinism` (updated score-ratchet assertion)</code>
- <code>`make paper-master-gate-test` — 9 master-provenance gate unit tests pass</code>
- <code>`python3 benchmarks/paper/plot_figure2b.py` render from regenerated JSON is byte-identical to committed `expected/figure2b.svg`</code>
- `Static check that regenerated figure2b curve has a monotone, continuously chained configured-score ratchet, and that the diff deletes no historical evidence (1,226-call reference retained in docs)`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
