### PR TITLE
chore(paper): add fixed-work TreeSA Pareto sweep with wall-time recording and verifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,15 @@ cost). Restore the old behavior with `preprocess: false`.
   emit the fields when the manifest sets `trace_scores: true` (implied by
   `trace_cuts`), and the `figure2b`/`waist_trace` verifiers now check the
   configured-score ratchet instead of raw `tc`.
+- Fixed-work Pareto sweep for the paper's time-versus-quality plot: six
+  `pareto_r{0,1,2,4,8,24}` benchmark sets run three deterministic tensor
+  relabelings each of `surfacecode_d21` and `sycamore_53_20_0` at 0–24
+  surgery/fine-tuning rounds. A new optional `record_time` manifest key makes
+  the runner emit each arm's measured wall time as `elapsed_s` — observed
+  after the algorithm finishes, never a timer, deadline, or stopping rule
+  inside TreeSA — and `benchmarks/paper/verify_pareto.py` checks the 36 runs
+  semantically, requiring one revision, manifest hash, and runner binary
+  across the sweep's provenance sidecars.
 - `Label` now requires `Ord` (all built-in label types already qualify).
 - The Julia behavioral-alignment rule is retired; JSON interop is unchanged.
 

--- a/benchmarks/paper/README.md
+++ b/benchmarks/paper/README.md
@@ -58,7 +58,7 @@ This directory is self-contained — manifest, instances, checker:
 | `check.py` | Compares two artifacts and exits nonzero on any disagreement. Standard library only, Python 3.8+. |
 | `verify_figure2b.py` | Verifies the record crossing, configured-score ratchet, and accepted-rebuild mechanism. |
 | `verify_waist_trace.py` | Verifies the `waist_trace` set: ten 128-round trajectories, per-round waist/FM cut invariants, and the rebuild gate/acceptance flags. |
-| `verify_pareto.py` | Verifies the six fixed-work Pareto sets, their measured wall times, and the configured-score ordering across round counts. |
+| `verify_pareto.py` | Verifies the six fixed-work Pareto sets, their measured wall times, and the configured-score ordering across round counts. Requires each artifact's `.provenance.json` sidecar and fails unless all six record one revision, manifest hash, and runner binary hash. |
 | `plot_figure2b.py` | Renders the checked JSON as a dependency-free vector figure. |
 | `README.md` | This file. |
 
@@ -127,6 +127,12 @@ done
 python3 benchmarks/paper/verify_pareto.py \
   "${pareto_dir}"/pareto_r{0,1,2,4,8,24}.json
 ```
+
+`verify_pareto.py` also reads the `<out>.provenance.json` sidecar that
+`run_master.py` writes next to each artifact. All six sidecars must be present,
+match their artifact's bytes, and record the same revision, manifest hash, and
+runner binary hash — a sweep mixing revisions or binaries (for example, after
+rerunning only some sets across an upstream `master` advance) cannot verify.
 
 The wrapper defaults to `benchmarks/paper/manifest.json` and the repository
 root. Its flags are:
@@ -247,11 +253,14 @@ random circuit costs time and reports nothing anyone wants to read.
 
 ## Determinism contract
 
-**On one machine, the artifact is byte-identical across runs.** Not "equal
-within tolerance" — the same bytes, and `diff` is the honest check there. CI
-compares with `check.py` instead, because the committed `expected/ci.json` and
-the CI runner need not share a platform. The guarantees behind byte-equality on
-one machine:
+**On one machine, an artifact from a set without `record_time` is
+byte-identical across runs.** Not "equal within tolerance" — the same bytes,
+and `diff` is the honest check there. CI compares with `check.py` instead,
+because the committed `expected/ci.json` and the CI runner need not share a
+platform. The `record_time` sets — the six Pareto sets — are the deliberate
+exception: their measured `elapsed_s` differs on every run, so neither `diff`
+nor `check.py`'s tolerance can pass on them; `verify_pareto.py` checks them
+semantically instead. The guarantees behind byte-equality on one machine:
 
 - Every RNG is seeded from a fixed constant plus a loop index. Trials are run in
   parallel with rayon but collected in index order, and the best is chosen by a
@@ -259,8 +268,9 @@ one machine:
 - The rounds loop counts rounds; it never watches the clock. Nothing in the
   pipeline is budgeted by wall time, so a slow machine and a fast machine take
   the same path.
-- The artifact carries no timestamp, hostname, thread count, or library
-  version — nothing that would make two correct runs differ.
+- Outside `record_time` sets, the artifact carries no timestamp, hostname,
+  thread count, or library version — nothing that would make two correct runs
+  differ.
 - Floats are rounded to six decimals before serialization, and every container
   in the output path is an ordered struct or an explicitly sorted `Vec`. No
   `HashMap` iteration order reaches the file.
@@ -271,9 +281,9 @@ Metropolis test calls them millions of times; a last-bit difference there can
 tip an accept/reject decision and change the whole trajectory. In practice the
 complexity metrics land in the same place, which is what `check.py`'s tolerance
 checks. So `check.py` is what CI runs, since the committed artifact and the
-runner need not share a platform; `diff` is the stricter check available when
-they do — regenerating locally and diffing against the committed file tells you
-whether *anything at all* moved.
+runner need not share a platform; for sets without `record_time`, `diff` is the
+stricter check available when they do — regenerating locally and diffing
+against the committed file tells you whether *anything at all* moved.
 
 The tolerance is relative — `abs(a - b) <= max(1e-9, 1e-9 * max(abs(a), abs(b)))`
 — because the fields being compared span twelve orders of magnitude. `tc`, `sc`

--- a/benchmarks/paper/README.md
+++ b/benchmarks/paper/README.md
@@ -58,6 +58,7 @@ This directory is self-contained — manifest, instances, checker:
 | `check.py` | Compares two artifacts and exits nonzero on any disagreement. Standard library only, Python 3.8+. |
 | `verify_figure2b.py` | Verifies the record crossing, configured-score ratchet, and accepted-rebuild mechanism. |
 | `verify_waist_trace.py` | Verifies the `waist_trace` set: ten 128-round trajectories, per-round waist/FM cut invariants, and the rebuild gate/acceptance flags. |
+| `verify_pareto.py` | Verifies the six fixed-work Pareto sets, their measured wall times, and the configured-score ordering across round counts. |
 | `plot_figure2b.py` | Renders the checked JSON as a dependency-free vector figure. |
 | `README.md` | This file. |
 
@@ -114,13 +115,26 @@ python3 benchmarks/paper/run_master.py \
     --set waist_trace \
     --out waist_trace.json
 python3 benchmarks/paper/verify_waist_trace.py waist_trace.json
+
+# Time-versus-quality Pareto inputs. Work is fixed at 0/1/2/4/8/24
+# rounds; elapsed time is measured, never used as an optimizer deadline.
+pareto_dir=$(mktemp -d)
+for rounds in 0 1 2 4 8 24; do
+  python3 benchmarks/paper/run_master.py \
+    --set "pareto_r${rounds}" \
+    --out "${pareto_dir}/pareto_r${rounds}.json"
+done
+python3 benchmarks/paper/verify_pareto.py \
+  "${pareto_dir}"/pareto_r{0,1,2,4,8,24}.json
 ```
 
 The wrapper defaults to `benchmarks/paper/manifest.json` and the repository
 root. Its flags are:
 
 - `--manifest <file>` — tracked manifest to read.
-- `--set <name>` — set within the manifest: `ci`, `figure2b`, `waist_trace`, or `full` (required).
+- `--set <name>` — set within the manifest: `ci`, `figure2b`, `waist_trace`,
+  `pareto_r0`, `pareto_r1`, `pareto_r2`, `pareto_r4`, `pareto_r8`,
+  `pareto_r24`, or `full` (required).
 - `--out <file>` — where to write the JSON artifact (required).
 - `--repo-root <dir>` — root that instance paths in the manifest resolve
   against; every selected instance must remain inside and tracked by this
@@ -206,6 +220,9 @@ random circuit costs time and reports nothing anyone wants to read.
 ```
 
 - `tc`, `sc`, `rwc` are `contraction_complexity` in log2 scale.
+- `elapsed_s` appears only when a set enables `record_time`. It measures the
+  arm's algorithm wall time. The Pareto sets use fixed work and merely observe
+  this duration; it is not a timer, deadline, or stopping rule inside TreeSA.
 - `curve` appears on `treesa_rounds` rows only. It is the log2 time-complexity
   trace from `RoundsReport::round_trace`: the retained incumbent before the
   round, the surgery candidate, the fine-tuning endpoint, and the retained
@@ -272,7 +289,8 @@ runner — if it changes a number, it is in `manifest.json` and it shows up in
 
 Allowed keys:
 
-- Set: `arms`, `instances`.
+- Set: `arms`, `instances`, `record_time` (optional; emit per-arm measured
+  `elapsed_s`).
 - Arm `greedy`: none; `{}` is the only legal value.
 - Arm `treesa`: `ntrials`, `niters`.
 - Arm `treesa_rounds`: `ntrials`, `niters`, `rounds` (required), `trace_cuts`
@@ -301,8 +319,11 @@ the directory, so an instance nobody declared is never silently benchmarked.
 
 ## Scope of the artifact
 
-The `full`, `figure2b`, `waist_trace`, and `ci` sets are the canonical sources
-for the paper's omeco results. Archived development campaigns may be useful
+The `full`, `figure2b`, `waist_trace`, `pareto_r0`, `pareto_r1`, `pareto_r2`,
+`pareto_r4`, `pareto_r8`, `pareto_r24`, and `ci` sets are the canonical sources
+for the paper's omeco results. The Pareto sets run three deterministic tensor
+relabelings each of `surfacecode_d21` and `sycamore_53_20_0`; each point is a
+fixed-work configuration whose wall time is measured afterward. Archived development campaigns may be useful
 for debugging or historical comparison, but they cannot supply manuscript
 numbers. When a paper
 table and a fresh current-`master` run disagree, the fresh run wins and the

--- a/benchmarks/paper/manifest.json
+++ b/benchmarks/paper/manifest.json
@@ -40,6 +40,78 @@
         {"name": "ksg_r4", "path": "benchmarks/paper/instances/ksg.json", "treewidth": false, "relabel_seed": 5504}
       ]
     },
+    "pareto_r0": {
+      "record_time": true,
+      "arms": {"treesa": {}},
+      "instances": [
+        {"name": "surfacecode_d21_r0", "path": "benchmarks/paper/instances/surfacecode_d21.json", "treewidth": false, "relabel_seed": 5600},
+        {"name": "surfacecode_d21_r1", "path": "benchmarks/paper/instances/surfacecode_d21.json", "treewidth": false, "relabel_seed": 5601},
+        {"name": "surfacecode_d21_r2", "path": "benchmarks/paper/instances/surfacecode_d21.json", "treewidth": false, "relabel_seed": 5602},
+        {"name": "sycamore_53_20_0_r0", "path": "benchmarks/paper/instances/sycamore_53_20_0.json", "treewidth": false, "relabel_seed": 5700},
+        {"name": "sycamore_53_20_0_r1", "path": "benchmarks/paper/instances/sycamore_53_20_0.json", "treewidth": false, "relabel_seed": 5701},
+        {"name": "sycamore_53_20_0_r2", "path": "benchmarks/paper/instances/sycamore_53_20_0.json", "treewidth": false, "relabel_seed": 5702}
+      ]
+    },
+    "pareto_r1": {
+      "record_time": true,
+      "arms": {"treesa_rounds": {"rounds": 1}},
+      "instances": [
+        {"name": "surfacecode_d21_r0", "path": "benchmarks/paper/instances/surfacecode_d21.json", "treewidth": false, "relabel_seed": 5600},
+        {"name": "surfacecode_d21_r1", "path": "benchmarks/paper/instances/surfacecode_d21.json", "treewidth": false, "relabel_seed": 5601},
+        {"name": "surfacecode_d21_r2", "path": "benchmarks/paper/instances/surfacecode_d21.json", "treewidth": false, "relabel_seed": 5602},
+        {"name": "sycamore_53_20_0_r0", "path": "benchmarks/paper/instances/sycamore_53_20_0.json", "treewidth": false, "relabel_seed": 5700},
+        {"name": "sycamore_53_20_0_r1", "path": "benchmarks/paper/instances/sycamore_53_20_0.json", "treewidth": false, "relabel_seed": 5701},
+        {"name": "sycamore_53_20_0_r2", "path": "benchmarks/paper/instances/sycamore_53_20_0.json", "treewidth": false, "relabel_seed": 5702}
+      ]
+    },
+    "pareto_r2": {
+      "record_time": true,
+      "arms": {"treesa_rounds": {"rounds": 2}},
+      "instances": [
+        {"name": "surfacecode_d21_r0", "path": "benchmarks/paper/instances/surfacecode_d21.json", "treewidth": false, "relabel_seed": 5600},
+        {"name": "surfacecode_d21_r1", "path": "benchmarks/paper/instances/surfacecode_d21.json", "treewidth": false, "relabel_seed": 5601},
+        {"name": "surfacecode_d21_r2", "path": "benchmarks/paper/instances/surfacecode_d21.json", "treewidth": false, "relabel_seed": 5602},
+        {"name": "sycamore_53_20_0_r0", "path": "benchmarks/paper/instances/sycamore_53_20_0.json", "treewidth": false, "relabel_seed": 5700},
+        {"name": "sycamore_53_20_0_r1", "path": "benchmarks/paper/instances/sycamore_53_20_0.json", "treewidth": false, "relabel_seed": 5701},
+        {"name": "sycamore_53_20_0_r2", "path": "benchmarks/paper/instances/sycamore_53_20_0.json", "treewidth": false, "relabel_seed": 5702}
+      ]
+    },
+    "pareto_r4": {
+      "record_time": true,
+      "arms": {"treesa_rounds": {"rounds": 4}},
+      "instances": [
+        {"name": "surfacecode_d21_r0", "path": "benchmarks/paper/instances/surfacecode_d21.json", "treewidth": false, "relabel_seed": 5600},
+        {"name": "surfacecode_d21_r1", "path": "benchmarks/paper/instances/surfacecode_d21.json", "treewidth": false, "relabel_seed": 5601},
+        {"name": "surfacecode_d21_r2", "path": "benchmarks/paper/instances/surfacecode_d21.json", "treewidth": false, "relabel_seed": 5602},
+        {"name": "sycamore_53_20_0_r0", "path": "benchmarks/paper/instances/sycamore_53_20_0.json", "treewidth": false, "relabel_seed": 5700},
+        {"name": "sycamore_53_20_0_r1", "path": "benchmarks/paper/instances/sycamore_53_20_0.json", "treewidth": false, "relabel_seed": 5701},
+        {"name": "sycamore_53_20_0_r2", "path": "benchmarks/paper/instances/sycamore_53_20_0.json", "treewidth": false, "relabel_seed": 5702}
+      ]
+    },
+    "pareto_r8": {
+      "record_time": true,
+      "arms": {"treesa_rounds": {"rounds": 8}},
+      "instances": [
+        {"name": "surfacecode_d21_r0", "path": "benchmarks/paper/instances/surfacecode_d21.json", "treewidth": false, "relabel_seed": 5600},
+        {"name": "surfacecode_d21_r1", "path": "benchmarks/paper/instances/surfacecode_d21.json", "treewidth": false, "relabel_seed": 5601},
+        {"name": "surfacecode_d21_r2", "path": "benchmarks/paper/instances/surfacecode_d21.json", "treewidth": false, "relabel_seed": 5602},
+        {"name": "sycamore_53_20_0_r0", "path": "benchmarks/paper/instances/sycamore_53_20_0.json", "treewidth": false, "relabel_seed": 5700},
+        {"name": "sycamore_53_20_0_r1", "path": "benchmarks/paper/instances/sycamore_53_20_0.json", "treewidth": false, "relabel_seed": 5701},
+        {"name": "sycamore_53_20_0_r2", "path": "benchmarks/paper/instances/sycamore_53_20_0.json", "treewidth": false, "relabel_seed": 5702}
+      ]
+    },
+    "pareto_r24": {
+      "record_time": true,
+      "arms": {"treesa_rounds": {"rounds": 24}},
+      "instances": [
+        {"name": "surfacecode_d21_r0", "path": "benchmarks/paper/instances/surfacecode_d21.json", "treewidth": false, "relabel_seed": 5600},
+        {"name": "surfacecode_d21_r1", "path": "benchmarks/paper/instances/surfacecode_d21.json", "treewidth": false, "relabel_seed": 5601},
+        {"name": "surfacecode_d21_r2", "path": "benchmarks/paper/instances/surfacecode_d21.json", "treewidth": false, "relabel_seed": 5602},
+        {"name": "sycamore_53_20_0_r0", "path": "benchmarks/paper/instances/sycamore_53_20_0.json", "treewidth": false, "relabel_seed": 5700},
+        {"name": "sycamore_53_20_0_r1", "path": "benchmarks/paper/instances/sycamore_53_20_0.json", "treewidth": false, "relabel_seed": 5701},
+        {"name": "sycamore_53_20_0_r2", "path": "benchmarks/paper/instances/sycamore_53_20_0.json", "treewidth": false, "relabel_seed": 5702}
+      ]
+    },
     "full": {
       "arms": {
         "greedy": {},

--- a/benchmarks/paper/verify_pareto.py
+++ b/benchmarks/paper/verify_pareto.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 """Verify the fixed-work, measured-time inputs for the paper Pareto plot."""
 
+import hashlib
 import json
 import math
 from pathlib import Path
@@ -21,15 +22,42 @@ def default_score(row: dict) -> float:
     return math.exp2(row["tc"]) + max(0.0, math.exp2(row["sc"]) - math.exp2(20.0))
 
 
+def load_provenance(artifact_path: Path, set_name: str, artifact_bytes: bytes) -> dict:
+    """Read the run_master.py sidecar next to an artifact and bind it to the bytes."""
+    sidecar = Path(f"{artifact_path}.provenance.json")
+    try:
+        record = json.loads(sidecar.read_text())
+    except (OSError, ValueError) as exc:
+        fail(f"cannot read provenance sidecar {sidecar}: {exc}")
+    if record.get("set") != set_name:
+        fail(f"{sidecar}: provenance records set {record.get('set')!r}, not {set_name!r}")
+    output = record.get("output")
+    recorded_hash = output.get("sha256") if isinstance(output, dict) else None
+    if recorded_hash != hashlib.sha256(artifact_bytes).hexdigest():
+        fail(f"{sidecar}: recorded output hash does not match {artifact_path}")
+    manifest = record.get("manifest")
+    fields = {
+        "revision": record.get("revision"),
+        "manifest_sha256": manifest.get("sha256") if isinstance(manifest, dict) else None,
+        "binary_sha256": record.get("binary_sha256"),
+    }
+    for key, value in fields.items():
+        if not isinstance(value, str) or not value:
+            fail(f"{sidecar}: missing or invalid {key}")
+    return fields
+
+
 def main() -> None:
     if len(sys.argv) != len(ROUNDS) + 1:
         fail("usage: verify_pareto.py pareto_r0.json pareto_r1.json ... pareto_r24.json")
 
     artifacts = {}
+    provenances = {}
     for argument in sys.argv[1:]:
         path = Path(argument)
         try:
-            data = json.loads(path.read_text())
+            raw = path.read_bytes()
+            data = json.loads(raw)
         except (OSError, ValueError) as exc:
             fail(f"cannot read {path}: {exc}")
         set_name = data.get("set")
@@ -38,10 +66,21 @@ def main() -> None:
         if set_name in artifacts:
             fail(f"duplicate artifact for {set_name}")
         artifacts[set_name] = data
+        provenances[set_name] = load_provenance(path, set_name, raw)
 
     expected_sets = {f"pareto_r{r}" for r in ROUNDS}
     if set(artifacts) != expected_sets:
         fail(f"expected sets {sorted(expected_sets)}, found {sorted(artifacts)}")
+
+    for key, label in (
+        ("revision", "revision"),
+        ("manifest_sha256", "manifest hash"),
+        ("binary_sha256", "runner binary hash"),
+    ):
+        values = {provenance[key] for provenance in provenances.values()}
+        if len(values) != 1:
+            fail(f"mixed {label} across the sweep: {sorted(values)}")
+    revision = provenances[f"pareto_r{ROUNDS[0]}"]["revision"]
 
     trajectories = {(family, repeat): [] for family in FAMILIES for repeat in range(3)}
     for rounds in ROUNDS:
@@ -96,7 +135,10 @@ def main() -> None:
         rows = artifacts[f"pareto_r{rounds}"]["results"]
         median_s = statistics.median(row["elapsed_s"] for row in rows)
         summaries.append(f"r{rounds}={median_s:.1f}s")
-    print("verified fixed-work Pareto sweep: 36 runs; median times " + ", ".join(summaries))
+    print(
+        f"verified fixed-work Pareto sweep: 36 runs at revision {revision[:12]}; "
+        "median times " + ", ".join(summaries)
+    )
 
 
 if __name__ == "__main__":

--- a/benchmarks/paper/verify_pareto.py
+++ b/benchmarks/paper/verify_pareto.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""Verify the fixed-work, measured-time inputs for the paper Pareto plot."""
+
+import json
+import math
+from pathlib import Path
+import statistics
+import sys
+
+
+ROUNDS = (0, 1, 2, 4, 8, 24)
+FAMILIES = ("surfacecode_d21", "sycamore_53_20_0")
+
+
+def fail(message: str) -> None:
+    raise SystemExit(f"pareto verification FAILED: {message}")
+
+
+def default_score(row: dict) -> float:
+    """TreeSA default score reconstructed from emitted log2 complexities."""
+    return math.exp2(row["tc"]) + max(0.0, math.exp2(row["sc"]) - math.exp2(20.0))
+
+
+def main() -> None:
+    if len(sys.argv) != len(ROUNDS) + 1:
+        fail("usage: verify_pareto.py pareto_r0.json pareto_r1.json ... pareto_r24.json")
+
+    artifacts = {}
+    for argument in sys.argv[1:]:
+        path = Path(argument)
+        try:
+            data = json.loads(path.read_text())
+        except (OSError, ValueError) as exc:
+            fail(f"cannot read {path}: {exc}")
+        set_name = data.get("set")
+        if data.get("format") != 2 or set_name not in {f"pareto_r{r}" for r in ROUNDS}:
+            fail(f"{path}: wrong artifact format or set")
+        if set_name in artifacts:
+            fail(f"duplicate artifact for {set_name}")
+        artifacts[set_name] = data
+
+    expected_sets = {f"pareto_r{r}" for r in ROUNDS}
+    if set(artifacts) != expected_sets:
+        fail(f"expected sets {sorted(expected_sets)}, found {sorted(artifacts)}")
+
+    trajectories = {(family, repeat): [] for family in FAMILIES for repeat in range(3)}
+    for rounds in ROUNDS:
+        data = artifacts[f"pareto_r{rounds}"]
+        rows = data.get("results")
+        if not isinstance(rows, list) or len(rows) != 6:
+            fail(f"pareto_r{rounds}: expected six results")
+        expected_arm = "treesa" if rounds == 0 else "treesa_rounds"
+        seen = set()
+        for row in rows:
+            name = row.get("instance", "")
+            match = next(
+                (
+                    (family, repeat)
+                    for family in FAMILIES
+                    for repeat in range(3)
+                    if name == f"{family}_r{repeat}"
+                ),
+                None,
+            )
+            if match is None or match in seen:
+                fail(f"pareto_r{rounds}: unexpected or duplicate instance {name!r}")
+            seen.add(match)
+            if row.get("arm") != expected_arm:
+                fail(f"pareto_r{rounds} {name}: expected arm {expected_arm}")
+            values = (row.get("tc"), row.get("sc"), row.get("rwc"), row.get("elapsed_s"))
+            if not all(isinstance(value, (int, float)) and math.isfinite(value) for value in values):
+                fail(f"pareto_r{rounds} {name}: missing or non-finite metric")
+            if row["elapsed_s"] <= 0:
+                fail(f"pareto_r{rounds} {name}: non-positive elapsed time")
+            curve = row.get("curve")
+            if rounds == 0:
+                if curve is not None:
+                    fail(f"pareto_r0 {name}: baseline unexpectedly has a round trace")
+            elif not isinstance(curve, list) or len(curve) != rounds:
+                fail(f"pareto_r{rounds} {name}: expected {rounds} curve points")
+            trajectories[match].append((rounds, default_score(row)))
+
+    for (family, repeat), trajectory in trajectories.items():
+        trajectory.sort()
+        for (before_rounds, before), (after_rounds, after) in zip(trajectory, trajectory[1:]):
+            # tc/sc are rounded to 1e-6 before score reconstruction, so allow
+            # the corresponding relative quantization band.
+            if after > before * (1.0 + 2e-6):
+                fail(
+                    f"{family}_r{repeat}: configured score rose from r{before_rounds} "
+                    f"to r{after_rounds}"
+                )
+
+    summaries = []
+    for rounds in ROUNDS:
+        rows = artifacts[f"pareto_r{rounds}"]["results"]
+        median_s = statistics.median(row["elapsed_s"] for row in rows)
+        summaries.append(f"r{rounds}={median_s:.1f}s")
+    print("verified fixed-work Pareto sweep: 36 runs; median times " + ", ".join(summaries))
+
+
+if __name__ == "__main__":
+    main()

--- a/omeco/examples/paper_bench.rs
+++ b/omeco/examples/paper_bench.rs
@@ -60,6 +60,9 @@ struct Manifest {
 struct SetSpec {
     arms: ArmsSpec,
     instances: Vec<InstanceSpec>,
+    /// Record per-arm algorithm wall time. This is publication metadata, not
+    /// an optimizer budget or stopping rule.
+    record_time: Option<bool>,
 }
 
 /// The arms a set may request. Modelled as a struct rather than a map so that
@@ -168,6 +171,9 @@ struct ResultRow {
     tc: f64,
     sc: f64,
     rwc: f64,
+    /// Algorithm wall time, emitted only by timing-enabled benchmark sets.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    elapsed_s: Option<f64>,
     /// Per-round retained-incumbent trace, emitted by `treesa_rounds` only.
     #[serde(skip_serializing_if = "Option::is_none")]
     curve: Option<Vec<CurvePoint>>,
@@ -335,6 +341,7 @@ fn row(
     tree: &NestedEinsum<usize>,
     code: &EinCode<usize>,
     sizes: &HashMap<usize, usize>,
+    elapsed_s: Option<f64>,
     curve: Option<Vec<CurvePoint>>,
 ) -> ResultRow {
     let cc = contraction_complexity(tree, sizes, &code.ixs);
@@ -344,8 +351,13 @@ fn row(
         tc: round6(cc.tc),
         sc: round6(cc.sc),
         rwc: round6(cc.rwc),
+        elapsed_s,
         curve,
     }
+}
+
+fn measured_elapsed(record_time: bool, started: &Instant) -> Option<f64> {
+    record_time.then(|| round6(started.elapsed().as_secs_f64()))
 }
 
 /// Run every arm the set requests on one instance.
@@ -354,6 +366,7 @@ fn run_instance(
     arms: &ArmsSpec,
     code: &EinCode<usize>,
     sizes: &HashMap<usize, usize>,
+    record_time: bool,
 ) -> Vec<ResultRow> {
     let mut rows = Vec::new();
     let optimized = |tree: Option<NestedEinsum<usize>>, arm: &str| match tree {
@@ -370,7 +383,15 @@ fn run_instance(
             optimize_code(code, sizes, &GreedyMethod::default()),
             "greedy",
         );
-        rows.push(row(&spec.name, "greedy", &tree, code, sizes, None));
+        rows.push(row(
+            &spec.name,
+            "greedy",
+            &tree,
+            code,
+            sizes,
+            measured_elapsed(record_time, &started),
+            None,
+        ));
         report_progress(&spec.name, "greedy", started);
     }
 
@@ -378,7 +399,15 @@ fn run_instance(
         let started = Instant::now();
         let config = treesa_config(arm.ntrials, arm.niters);
         let tree = optimized(optimize_code(code, sizes, &config), "treesa");
-        rows.push(row(&spec.name, "treesa", &tree, code, sizes, None));
+        rows.push(row(
+            &spec.name,
+            "treesa",
+            &tree,
+            code,
+            sizes,
+            measured_elapsed(record_time, &started),
+            None,
+        ));
         report_progress(&spec.name, "treesa", started);
     }
 
@@ -428,6 +457,7 @@ fn run_instance(
             &tree,
             code,
             sizes,
+            measured_elapsed(record_time, &started),
             Some(curve),
         ));
         report_progress(&spec.name, "treesa_rounds", started);
@@ -450,6 +480,7 @@ fn run_instance(
             &tree,
             code,
             sizes,
+            measured_elapsed(record_time, &started),
             None,
         ));
         report_progress(&spec.name, "treesa_surgery_rule", started);
@@ -461,7 +492,15 @@ fn run_instance(
             optimize_code(code, sizes, &Treewidth::default()),
             "treewidth",
         );
-        rows.push(row(&spec.name, "treewidth", &tree, code, sizes, None));
+        rows.push(row(
+            &spec.name,
+            "treewidth",
+            &tree,
+            code,
+            sizes,
+            measured_elapsed(record_time, &started),
+            None,
+        ));
         report_progress(&spec.name, "treewidth", started);
     }
 
@@ -497,7 +536,13 @@ fn main() {
         let path = args.repo_root.join(&spec.path);
         let data: InstanceData = read_json(&path, "instance");
         let (code, sizes) = build_instance(data, &path, spec.relabel_seed);
-        results.extend(run_instance(spec, &set.arms, &code, &sizes));
+        results.extend(run_instance(
+            spec,
+            &set.arms,
+            &code,
+            &sizes,
+            set.record_time.unwrap_or(false),
+        ));
     }
 
     // Row order must not depend on manifest order or on iteration order
@@ -529,7 +574,7 @@ fn main() {
 
 #[cfg(test)]
 mod tests {
-    use super::{permute_tensors, CurvePoint, RoundsArm};
+    use super::{permute_tensors, CurvePoint, ResultRow, RoundsArm};
 
     #[test]
     fn tensor_relabeling_is_seeded_and_deterministic() {
@@ -586,5 +631,23 @@ mod tests {
         let traced = serde_json::to_value(point(Some(2.0), Some(1.5))).unwrap();
         assert_eq!(traced["score_before"], 2.0);
         assert_eq!(traced["score_retained"], 1.5);
+    }
+
+    #[test]
+    fn elapsed_time_is_an_opt_in_artifact_field() {
+        let result = |elapsed_s| ResultRow {
+            instance: "test".to_string(),
+            arm: "treesa".to_string(),
+            tc: 1.0,
+            sc: 1.0,
+            rwc: 1.0,
+            elapsed_s,
+            curve: None,
+        };
+
+        let ordinary = serde_json::to_value(result(None)).unwrap();
+        assert!(ordinary.get("elapsed_s").is_none());
+        let timed = serde_json::to_value(result(Some(2.5))).unwrap();
+        assert_eq!(timed["elapsed_s"], 2.5);
     }
 }


### PR DESCRIPTION
## Intent

Restore the paper's time-versus-quality Pareto plot without reusing stale OMECO campaign points. Define a tracked current-master sweep over fixed TreeSA work (0, 1, 2, 4, 8, and 24 surgery/fine-tuning rounds), with three matched deterministic tensor relabelings each of surfacecode_d21 and sycamore_53_20_0. Measure each arm's wall time only after the algorithm executes; do not add a timer, deadline, or time-based stopping rule to TreeSA. Keep existing ci/full/figure2b/waist_trace artifact schemas unchanged, enforce the exact-master paper gate, and provide a semantic verifier for the 36 Pareto runs.

## What Changed

- Added six tracked benchmark sets `pareto_r{0,1,2,4,8,24}` to `benchmarks/paper/manifest.json`, each running TreeSA at a fixed number of surgery/fine-tuning rounds over the same three seeded deterministic relabelings of `surfacecode_d21` and `sycamore_53_20_0` (36 runs total), replacing the stale campaign points behind the paper's time-versus-quality Pareto plot.
- Extended `omeco/examples/paper_bench.rs` with an opt-in `record_time` set flag that emits an `elapsed_s` field per result row, measured only after `optimize_code` returns — no timer, deadline, or time-based stopping rule touches TreeSA, and the existing `ci`/`full`/`figure2b`/`waist_trace` artifact schemas stay byte-identical (the field is skipped when unset).
- Added `benchmarks/paper/verify_pareto.py`, a semantic verifier for the sweep that checks the 36 runs for matched instances/seeds across round counts, configured-score monotonicity as rounds increase, and single-revision provenance via the `.provenance.json` sidecars; the README documents the sweep workflow and scopes the byte-stability determinism contract to sets without `record_time`, since measured wall time varies between runs.

## Risk Assessment

✅ Low: The fix commit correctly implements both requested round-1 remedies (scoping the determinism contract to non-record_time sets and hard-gating the Pareto sweep on six byte-bound provenance sidecars with one revision/manifest/binary hash), touches only docs and the verifier, and leaves every intent constraint satisfied with no new issues found.

## Testing

Ran the runner unit tests and the 9 paper-gate tests (all pass), proved existing artifact schemas byte-unchanged by regenerating ci and diffing against the committed expected artifact, then demonstrated the sweep end-to-end with the real release binary on a structurally identical reduced-cost pareto manifest: verify_pareto.py accepted the 36 real runs with provenance sidecars and rejected all four negative controls (missing sidecar, tampered bytes, mixed revision, score regression); a re-run differed only in elapsed_s, and the diff adds no timing logic to TreeSA. The full-scale campaign on surfacecode_d21/sycamore_53_20_0 was not run because it takes hours and the exact-master gate intentionally blocks pre-merge branches; the reduced sweep exercises the identical code paths and set structure. No UI surface is involved, so evidence is CLI transcripts and JSON artifacts.

<details>
<summary>Evidence: Full test transcript (commands, outputs, negative controls, sample rows)</summary>

```text
# Test transcript: fixed-work Pareto sweep (branch `bench/fixed-work-pareto`, ae771b9)

All commands were run in the isolated worktree at commit `ae771b9`. The full
36-run paper sweep on `surfacecode_d21`/`sycamore_53_20_0` at default TreeSA
settings is a multi-hour campaign, so the end-to-end demonstration uses the
real `paper_bench` release binary with a manifest that mirrors the pareto set
structure exactly (same six set names, same six instance names, same
`record_time` flag, same rounds 0/1/2/4/8/24, seeded relabelings) but points
at the smaller `surfacecode_d9` instance with `ntrials=4, niters=30`.

## 1. Unit tests (runner) — pass

`` `
$ cargo test --example paper_bench -p omeco
running 4 tests
test tests::score_fields_follow_either_trace_flag ... ok
test tests::elapsed_time_is_an_opt_in_artifact_field ... ok
test tests::trace_scores_are_opt_in_artifact_fields ... ok
test tests::tensor_relabeling_is_seeded_and_deterministic ... ok
test result: ok. 4 passed; 0 failed
`` `

## 2. Existing paper-gate tests — pass

`` `
$ python3 benchmarks/paper/test_run_master.py
Ran 9 tests in 4.210s
OK
`` `

`run_master.py`'s exact-master gate is unchanged and still refuses any HEAD
that is not current `origin/master` (covered by
`test_verify_master_rejects_non_master_head`); this branch itself cannot pass
the gate, which is the gate working as designed.

## 3. Existing artifact schemas unchanged — `ci` byte-identical

`` `
$ ./target/release/examples/paper_bench --manifest benchmarks/paper/manifest.json \
    --set ci --out $SCRATCH/ci.json --repo-root .
paper_bench: wrote .../ci.json (17 results, 20.7s)
$ diff benchmarks/paper/expected/ci.json $SCRATCH/ci.json && echo "CI ARTIFACT BYTE-IDENTICAL"
CI ARTIFACT BYTE-IDENTICAL
`` `

`elapsed_s` is `skip_serializing_if = None` and only emitted when a set sets
`record_time`; no existing set does, so `ci`/`full`/`figure2b`/`waist_trace`
bytes are untouched.

## 4. End-to-end sweep with the real binary — 36 runs, verifier passes

`` `
$ for rounds in 0 1 2 4 8 24; do ./target/release/examples/paper_bench \
    --manifest $SCRATCH/pareto_manifest.json --set pareto_r${rounds} \
    --out $SCRATCH/pareto_r${rounds}.json --repo-root .; done
paper_bench: wrote .../pareto_r0.json (6 results, 2.8s)
paper_bench: wrote .../pareto_r1.json (6 results, 3.4s)
paper_bench: wrote .../pareto_r2.json (6 results, 3.7s)
paper_bench: wrote .../pareto_r4.json (6 results, 4.6s)
paper_bench: wrote .../pareto_r8.json (6 results, ...)
paper_bench: wrote .../pareto_r24.json (6 results, ...)

$ python3 benchmarks/paper/verify_pareto.py $SCRATCH/pareto_r{0,1,2,4,8,24}.json
verified fixed-work Pareto sweep: 36 runs at revision ae771b99b751; median times r0=0.5s, r1=0.5s, r2=0.6s, r4=0.8s, r8=1.0s, r24=2.5s
exit=0
`` `

Provenance sidecars were written in `run_master.py`'s exact record format
(one shared revision, manifest hash, binary hash, per-artifact output sha256).
Median measured time rises monotonically with the fixed round count — the
time axis of the Pareto plot comes from measurement, not from any budget.

## 5. Verifier negative controls — all rejected

`` `
control 1 (delete one sidecar):
pareto verification FAILED: cannot read provenance sidecar .../pareto_r4.json.provenance.json: [Errno 2] ...
control 2 (tamper artifact bytes, keep sidecar):
pareto verification FAILED: .../pareto_r8.json.provenance.json: recorded output hash does not match .../pareto_r8.json
control 3 (one sidecar records a different revision):
pareto verification FAILED: mixed revision across the sweep: ['ae771b99...', 'f0fd19a1...']
control 4 (raise r24 tc for one instance, recompute sidecar hash):
pareto verification FAILED: surfacecode_d21_r0: configured score rose from r8 to r24
`` `

Each control exits nonzero. A sweep mixing revisions/binaries, a stale or
edited artifact, or a quality regression at higher fixed work cannot verify.

## 6. Scoped determinism contract — only `elapsed_s` varies across re-runs

`` `
$ ./target/release/examples/paper_bench ... --set pareto_r4 --out pareto_r4_rerun.json ...
identical apart from elapsed_s: True
elapsed_s run1: [0.757872, 0.743533, 0.768383, 0.766068, 0.750704, 0.791229]
elapsed_s run2: [0.87525, 1.136565, 0.962621, 0.87313, 0.919847, 0.84304]
`` `

## 7. Sample artifact rows

`pareto_r4`, arm `treesa_rounds` (curve = 4 round entries, truncated):

`` `json
{
 "instance": "surfacecode_d21_r0",
 "arm": "treesa_rounds",
 "tc": 21.767029, "sc": 16.0, "rwc": 20.339225,
 "elapsed_s": 0.757872,
 "curve": [ {"round": 0, "tc_before": 21.768897, ... , "surgery_accepted": false}, "..." ]
}
`` `

`pareto_r0` baseline, arm `treesa` (no curve, timed):

`` `json
{
 "instance": "surfacecode_d21_r0",
 "arm": "treesa",
 "tc": 21.771252, "sc": 16.0, "rwc": 19.942882,
 "elapsed_s": 0.416122
}
`` `

## 8. Forbidden-constraint check — no timer inside TreeSA

`git diff f0fd19a..ae771b9 --stat` touches only `benchmarks/paper/README.md`,
`benchmarks/paper/manifest.json`, `benchmarks/paper/verify_pareto.py`, and
`omeco/examples/paper_bench.rs`. Nothing under `omeco/src/` changes; in the
runner, `started.elapsed()` is read only after `optimize_code` returns and the
value is never passed into any optimizer configuration.

## Artifacts

`pareto_sweep/` in this evidence directory contains the six real artifacts,
their provenance sidecars, and the reduced-cost manifest used for the run.
```
</details>
- Evidence: Six real pareto artifacts + provenance sidecars + reduced-cost manifest (local file: <code>/var/folders/nn/smw2hcnx18z1l6blf_p59x740000gn/T/no-mistakes-evidence/01KZ5259HDKJREPFHKQPDNKTF9/pareto_sweep</code>)
<details>
<summary>Evidence: verify_pareto.py pass on 36 real runs</summary>

```text
$ python3 benchmarks/paper/verify_pareto.py pareto_r{0,1,2,4,8,24}.json
verified fixed-work Pareto sweep: 36 runs at revision ae771b99b751; median times r0=0.5s, r1=0.5s, r2=0.6s, r4=0.8s, r8=1.0s, r24=2.5s
```
</details>
<details>
<summary>Evidence: Negative controls all rejected</summary>

```text
missing sidecar -> FAILED: cannot read provenance sidecar .../pareto_r4.json.provenance.json
tampered bytes -> FAILED: recorded output hash does not match .../pareto_r8.json
mixed revision -> FAILED: mixed revision across the sweep: ['ae771b99...', 'f0fd19a1...']
score regression -> FAILED: surfacecode_d21_r0: configured score rose from r8 to r24
```
</details>
<details>
<summary>Evidence: Existing ci artifact byte-identical after change</summary>

```text
$ diff benchmarks/paper/expected/ci.json $SCRATCH/ci.json && echo CI ARTIFACT BYTE-IDENTICAL
CI ARTIFACT BYTE-IDENTICAL
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 3 issues found → auto-fixed ✅</summary>

- ⚠️ `benchmarks/paper/README.md:250` - The README&#39;s &#34;Determinism contract&#34; section is now inaccurate for record_time sets: line 250 promises the artifact is byte-identical across runs on one machine and line 262 states it &#34;carries no timestamp, hostname, thread count, or library version — nothing that would make two correct runs differ&#34;, but the six new pareto sets embed wall-clock `elapsed_s`, which differs on every run. Following the documented &#34;regenerate locally and diff&#34; check on a pareto artifact always reports a mismatch, and check.py&#39;s 1e-9 relative tolerance would likewise always fail on elapsed_s. Fix: scope the byte-stability/diff contract to sets without `record_time` (the new elapsed_s bullet already explains the semantics; the contract section just needs the carve-out).
- ℹ️ `benchmarks/paper/verify_pareto.py:27` - verify_pareto.py verifies cross-artifact properties (configured-score monotonicity across round counts, wall-time comparability) that only hold when all six artifacts come from the same revision and machine, but it never checks this. The master gate makes a mid-sweep upstream advance fail loudly at generation time, yet a user who reruns only the remaining sets after such a failure can silently feed a mixed-revision sweep to the verifier. Optional hardening: when the `.provenance.json` sidecars written by run_master.py are present next to the artifacts, verify their `revision` fields agree.
- ℹ️ `benchmarks/paper/README.md:121` - Sibling paper sets have Makefile entry points (paper-figure2b-check, paper-waist-trace), but the pareto sweep and its verifier are only documented as a raw shell loop in the README even though the Makefile is the project&#39;s primary interface. Likely deliberate given the multi-hour runtime of the r24 sycamore runs; noted for consistency as a possible follow-up target.

🔧 Fix: scope determinism contract and gate Pareto sweep on provenance
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`cargo test --example paper_bench -p omeco` (4 tests incl. new elapsed_s opt-in field test)</code>
- <code>`python3 benchmarks/paper/test_run_master.py` (9 exact-master gate tests)</code>
- <code>Regenerated `ci` set with the new release binary and `diff`ed against committed `expected/ci.json` — byte-identical, proving elapsed_s does not leak into existing ci/full/figure2b/waist_trace schemas (parsing the tracked manifest also validated all six pareto set definitions under serde deny_unknown_fields)</code>
- <code>Ran the real `paper_bench` binary on all six pareto sets (rounds 0/1/2/4/8/24, same set/instance names and seeded relabelings as the tracked manifest, reduced to surfacecode_d9 with ntrials=4/niters=30 since the true campaign is multi-hour), wrote run_master.py-format provenance sidecars, and ran `python3 benchmarks/paper/verify_pareto.py pareto_r{0,1,2,4,8,24}.json` — passed, reporting 36 runs at one revision with median time rising monotonically r0=0.5s→r24=2.5s</code>
- `Four verify_pareto.py negative controls: deleted sidecar, tampered artifact bytes, mixed revision across sidecars, and configured-score rise from r8 to r24 — each exits nonzero with a precise diagnostic`
- `Re-ran pareto_r4 and compared artifacts with elapsed_s stripped — identical, confirming the scoped determinism contract (only measured time varies)`
- <code>Inspected `git diff f0fd19a..ae771b9` to confirm omeco/src is untouched and elapsed time is measured only after optimize_code returns, never fed into any optimizer config</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
