### PR TITLE
fix(clippy): BitSet::clear fill for rust 1.98

### DIFF
--- a/omeco/src/expr_tree.rs
+++ b/omeco/src/expr_tree.rs
@@ -27,9 +27,7 @@ impl BitSet {
     /// Clear all bits.
     #[inline]
     pub fn clear(&mut self) {
-        for word in &mut self.bits {
-            *word = 0;
-        }
+        self.bits.fill(0);
     }
 
     /// Set a bit.


### PR DESCRIPTION
Master CI (stable 1.98, rolled 2026-08-20) fails clippy on `clippy::manual_slice_fill` in BitSet::clear. Replace the manual zero loop with `self.bits.fill(0)`.

Verified locally with rustc 1.98.0: `cargo clippy --workspace --all-targets --all-features -- -D warnings` and `cargo test --workspace --all-features` both pass.